### PR TITLE
refactor: Social패키지 재정리 및 통합 #6

### DIFF
--- a/src/main/java/cmc/delta/domain/auth/api/SocialAuthController.java
+++ b/src/main/java/cmc/delta/domain/auth/api/SocialAuthController.java
@@ -1,9 +1,9 @@
 package cmc.delta.domain.auth.api;
 
-import cmc.delta.domain.auth.api.dto.KakaoLoginData;
-import cmc.delta.domain.auth.api.dto.KakaoLoginRequest;
+import cmc.delta.domain.auth.api.dto.response.SocialLoginData;
+import cmc.delta.domain.auth.api.dto.request.SocialLoginRequest;
 import cmc.delta.domain.auth.application.AuthHeaderConstants;
-import cmc.delta.domain.auth.application.KakaoAuthService;
+import cmc.delta.domain.auth.application.SocialAuthFacade;
 import cmc.delta.domain.auth.application.port.TokenIssuer;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -15,15 +15,15 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
-public class KakaoAuthController {
+public class SocialAuthController {
 
-	private final KakaoAuthService kakaoAuthService;
+	private final SocialAuthFacade kakaoAuthService;
 
 	@PostMapping("/kakao")
-	public KakaoLoginData login(
+	public SocialLoginData login(
 		@Valid @RequestBody
-		KakaoLoginRequest request, HttpServletResponse response) {
-		KakaoAuthService.LoginResult result = kakaoAuthService.loginWithCode(request.code());
+		SocialLoginRequest request, HttpServletResponse response) {
+		SocialAuthFacade.LoginResult result = kakaoAuthService.loginWithCode(request.code());
 
 		TokenIssuer.IssuedTokens tokens = result.tokens();
 		response.setHeader(HttpHeaders.AUTHORIZATION, tokens.authorizationHeaderValue());

--- a/src/main/java/cmc/delta/domain/auth/api/dto/KakaoLoginData.java
+++ b/src/main/java/cmc/delta/domain/auth/api/dto/KakaoLoginData.java
@@ -1,7 +1,0 @@
-package cmc.delta.domain.auth.api.dto;
-
-public record KakaoLoginData(String email, String nickname, boolean isNewUser) {
-	public static KakaoLoginData of(String email, String nickname, boolean isNewUser) {
-		return new KakaoLoginData(email, nickname, isNewUser);
-	}
-}

--- a/src/main/java/cmc/delta/domain/auth/api/dto/KakaoLoginRequest.java
+++ b/src/main/java/cmc/delta/domain/auth/api/dto/KakaoLoginRequest.java
@@ -1,7 +1,0 @@
-package cmc.delta.domain.auth.api.dto;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record KakaoLoginRequest(@NotBlank
-String code) {
-}

--- a/src/main/java/cmc/delta/domain/auth/api/dto/request/SocialLoginRequest.java
+++ b/src/main/java/cmc/delta/domain/auth/api/dto/request/SocialLoginRequest.java
@@ -1,0 +1,7 @@
+package cmc.delta.domain.auth.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SocialLoginRequest(@NotBlank
+String code) {
+}

--- a/src/main/java/cmc/delta/domain/auth/api/dto/response/SocialAccountData.java
+++ b/src/main/java/cmc/delta/domain/auth/api/dto/response/SocialAccountData.java
@@ -1,0 +1,4 @@
+package cmc.delta.domain.auth.api.dto.response;
+
+public class SocialAccountData {
+}

--- a/src/main/java/cmc/delta/domain/auth/api/dto/response/SocialLoginData.java
+++ b/src/main/java/cmc/delta/domain/auth/api/dto/response/SocialLoginData.java
@@ -1,0 +1,7 @@
+package cmc.delta.domain.auth.api.dto.response;
+
+public record SocialLoginData(String email, String nickname, boolean isNewUser) {
+	public static SocialLoginData of(String email, String nickname, boolean isNewUser) {
+		return new SocialLoginData(email, nickname, isNewUser);
+	}
+}

--- a/src/main/java/cmc/delta/domain/auth/application/SocialAuthFacade.java
+++ b/src/main/java/cmc/delta/domain/auth/application/SocialAuthFacade.java
@@ -1,6 +1,6 @@
 package cmc.delta.domain.auth.application;
 
-import cmc.delta.domain.auth.api.dto.KakaoLoginData;
+import cmc.delta.domain.auth.api.dto.response.SocialLoginData;
 import cmc.delta.domain.auth.application.port.SocialOAuthClient;
 import cmc.delta.domain.auth.application.port.TokenIssuer;
 import cmc.delta.global.config.security.principal.UserPrincipal;
@@ -13,7 +13,7 @@ import org.springframework.util.StringUtils;
 /** 카카오 로그인 플로우를 오케스트레이션. */
 @Service
 @RequiredArgsConstructor
-public class KakaoAuthService {
+public class SocialAuthFacade {
 
 	private static final String DEFAULT_ROLE = "USER"; // role claim용(실서비스는 DB 조회로 교체)
 
@@ -33,7 +33,7 @@ public class KakaoAuthService {
 		UserPrincipal principal = new UserPrincipal(userId, DEFAULT_ROLE);
 		TokenIssuer.IssuedTokens tokens = tokenIssuer.issue(principal);
 
-		return new LoginResult(KakaoLoginData.of(email, nickname, false), tokens);
+		return new LoginResult(SocialLoginData.of(email, nickname, false), tokens);
 	}
 
 	private long parseUserId(String providerUserId) {
@@ -51,6 +51,6 @@ public class KakaoAuthService {
 		return value;
 	}
 
-	public record LoginResult(KakaoLoginData data, TokenIssuer.IssuedTokens tokens) {
+	public record LoginResult(SocialLoginData data, TokenIssuer.IssuedTokens tokens) {
 	}
 }

--- a/src/main/java/cmc/delta/domain/auth/application/SocialAuthService.java
+++ b/src/main/java/cmc/delta/domain/auth/application/SocialAuthService.java
@@ -1,3 +1,0 @@
-package cmc.delta.domain.auth.application;
-
-public class SocialAuthService {}

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/AppleOAuthClient.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/AppleOAuthClient.java
@@ -1,3 +1,0 @@
-package cmc.delta.domain.auth.infrastructure.oauth;
-
-public class AppleOAuthClient {}

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/apple/AppleIdTokenVerifier.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/apple/AppleIdTokenVerifier.java
@@ -1,0 +1,4 @@
+package cmc.delta.domain.auth.infrastructure.oauth.apple;
+
+public class AppleIdTokenVerifier {
+}

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/apple/AppleOAuthClient.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/apple/AppleOAuthClient.java
@@ -1,0 +1,3 @@
+package cmc.delta.domain.auth.infrastructure.oauth.apple;
+
+public class AppleOAuthClient {}

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/apple/AppleOAuthConfig.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/apple/AppleOAuthConfig.java
@@ -1,0 +1,4 @@
+package cmc.delta.domain.auth.infrastructure.oauth.apple;
+
+public class AppleOAuthConfig {
+}

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/apple/AppleOAuthProperties.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/apple/AppleOAuthProperties.java
@@ -1,0 +1,4 @@
+package cmc.delta.domain.auth.infrastructure.oauth.apple;
+
+public class AppleOAuthProperties {
+}

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/client/OAuthClientExceptionMapper.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/client/OAuthClientExceptionMapper.java
@@ -1,0 +1,4 @@
+package cmc.delta.domain.auth.infrastructure.oauth.client;
+
+public class OAuthClientExceptionMapper {
+}

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/client/OAuthHttpClient.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/client/OAuthHttpClient.java
@@ -1,0 +1,4 @@
+package cmc.delta.domain.auth.infrastructure.oauth.client;
+
+public class OAuthHttpClient {
+}

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/kakao/KakaoOAuthClient.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/kakao/KakaoOAuthClient.java
@@ -1,4 +1,4 @@
-package cmc.delta.domain.auth.infrastructure.oauth;
+package cmc.delta.domain.auth.infrastructure.oauth.kakao;
 
 import cmc.delta.domain.auth.application.port.SocialOAuthClient;
 import cmc.delta.global.error.ErrorCode;

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/kakao/KakaoOAuthConfig.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/kakao/KakaoOAuthConfig.java
@@ -1,4 +1,4 @@
-package cmc.delta.domain.auth.infrastructure.oauth;
+package cmc.delta.domain.auth.infrastructure.oauth.kakao;
 
 import java.time.Duration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/kakao/KakaoOAuthProperties.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/kakao/KakaoOAuthProperties.java
@@ -1,4 +1,4 @@
-package cmc.delta.domain.auth.infrastructure.oauth;
+package cmc.delta.domain.auth.infrastructure.oauth.kakao;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/kakao/KakaoTokenResponse.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/kakao/KakaoTokenResponse.java
@@ -1,4 +1,4 @@
-package cmc.delta.domain.auth.infrastructure.oauth;
+package cmc.delta.domain.auth.infrastructure.oauth.kakao;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/kakao/KakaoUserResponse.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/kakao/KakaoUserResponse.java
@@ -1,4 +1,4 @@
-package cmc.delta.domain.auth.infrastructure.oauth;
+package cmc.delta.domain.auth.infrastructure.oauth.kakao;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/token/redis/NoOpAccessBlacklistStore.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/token/redis/NoOpAccessBlacklistStore.java
@@ -1,4 +1,4 @@
-package cmc.delta.domain.auth.infrastructure.redis;
+package cmc.delta.domain.auth.infrastructure.oauth.token.redis;
 
 import cmc.delta.domain.auth.application.port.AccessBlacklistStore;
 import java.time.Duration;

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/token/redis/RedisAccessBlacklistStore.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/token/redis/RedisAccessBlacklistStore.java
@@ -1,4 +1,4 @@
-package cmc.delta.domain.auth.infrastructure.redis;
+package cmc.delta.domain.auth.infrastructure.oauth.token.redis;
 
 import cmc.delta.domain.auth.application.port.AccessBlacklistStore;
 import java.time.Duration;

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/token/redis/RedisRefreshTokenStore.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/oauth/token/redis/RedisRefreshTokenStore.java
@@ -1,4 +1,4 @@
-package cmc.delta.domain.auth.infrastructure.redis;
+package cmc.delta.domain.auth.infrastructure.oauth.token.redis;
 
 import cmc.delta.domain.auth.application.port.RefreshTokenStore;
 import java.time.Duration;

--- a/src/main/java/cmc/delta/domain/auth/infrastructure/persistence/SocialAccountJpaRepository.java
+++ b/src/main/java/cmc/delta/domain/auth/infrastructure/persistence/SocialAccountJpaRepository.java
@@ -1,3 +1,0 @@
-package cmc.delta.domain.auth.infrastructure.persistence;
-
-public class SocialAccountJpaRepository {}

--- a/src/main/java/cmc/delta/domain/auth/persistence/SocialAccountJpaRepository.java
+++ b/src/main/java/cmc/delta/domain/auth/persistence/SocialAccountJpaRepository.java
@@ -1,0 +1,3 @@
+package cmc.delta.domain.auth.persistence;
+
+public class SocialAccountJpaRepository {}


### PR DESCRIPTION
**Ⅰ. PR 내용 설명 (Describe what this PR did)**  
카카오 중심으로 구성되어 있던 소셜 로그인 구조를 Social 단위로 통합했습니다.  
API, DTO, Service 명을 Social 기준으로 변경하고, OAuth 및 토큰 관련 패키지를 역할 기준으로 재정리했습니다.  
추후 Apple 등 다른 소셜 로그인을 확장하기 위한 구조 정리 목적의 리팩터링입니다.

**Ⅱ. 관련 이슈 (Does this pull request fix one issue?)**  
fixes #6

**Ⅲ. 검증 방법 (Describe how to verify it)**  
카카오 로그인 API(`/api/v1/auth/kakao`) 호출 후 토큰 및 응답 값이 정상 반환되는지 확인했습니다.

**Ⅳ. 리뷰 시 참고 사항 (Special notes for reviews)**  
기능 변경은 없으며 구조 리팩터링 위주의 변경입니다.  
Apple 관련 클래스는 추후 구현을 위한 스켈레톤입니다.
