### PR TITLE
hotfix: KAKAO 버셀 허용

### DIFF
--- a/src/main/java/cmc/delta/global/config/security/SecurityConfig.java
+++ b/src/main/java/cmc/delta/global/config/security/SecurityConfig.java
@@ -97,6 +97,7 @@ public class SecurityConfig {
 		api.setAllowedOriginPatterns(List.of(
 			"https://dev.deltasemo.cloud",
 			"https://deltasemo.cloud",
+			"https://semo-xi.vercel.app",
 			"http://localhost:*"));
 		api.setAllowedMethods(List.of("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"));
 		api.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
**Ⅰ. PR 내용 설명 (Describe what this PR did)**
카카오 OAuth 프리플라이트(OPTIONS) 403을 막기 위해 CORS 허용 Origin에 https://semo-xi.vercel.app를 추가했습니다.

**Ⅱ. 관련 이슈 (Does this pull request fix one issue?)**

**Ⅲ. 검증 방법 (Describe how to verify it)**
- ./gradlew test  
- 프리플라이트 확인:
    curl -i -X OPTIONS "https://<api-domain>/api/v1/auth/kakao" \
    -H "Origin: https://semo-xi.vercel.app" \
    -H "Access-Control-Request-Method: POST"
  
**Ⅳ. 리뷰 시 참고 사항 (Special notes for reviews)**
- ./gradlew build는 기존 Spotless 포맷 위반으로 실패할 수 있습니다.