### PR TITLE
config: 운영 프론트 base URL을 애플 리다이렉트 기본값으로 설정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,6 +12,9 @@ spring:
     activate:
       on-profile: prod
 
+frontend:
+  base-url: ${FRONTEND_BASE_URL:https://semo-xi.vercel.app}
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${PROD_DB_URL}


### PR DESCRIPTION
**Ⅰ. PR 내용 설명 (Describe what this PR did)**
운영 환경에서 애플 로그인 리다이렉트가 https://semo-xi.vercel.app로 향하도록 frontend.base-url 기본값을 application-prod.yml에 추가했습니다.
**Ⅱ. 관련 이슈 (Does this pull request fix one issue?)**  
없음
**Ⅲ. 검증 방법 (Describe how to verify it)**  
- ./gradlew test  
- ./gradlew build (Spotless 포맷 위반으로 실패 — 기존 파일 문제)

**Ⅳ. 리뷰 시 참고 사항 (Special notes for reviews)**  
- FRONTEND_BASE_URL 환경변수가 없으면 기본값으로 배포 URL을 사용합니다.  
- Spotless 위반은 이번 변경과 무관한 기존 파일에서 발생했습니다.