### PR TITLE
feat: discord 신규회원가입 로직 머지

### DIFF
--- a/src/main/java/cmc/delta/domain/auth/application/service/provisioning/UserProvisioningServiceImpl.java
+++ b/src/main/java/cmc/delta/domain/auth/application/service/provisioning/UserProvisioningServiceImpl.java
@@ -1,5 +1,10 @@
 package cmc.delta.domain.auth.application.service.provisioning;
 
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
 import cmc.delta.domain.auth.application.port.in.provisioning.SocialUserProvisionCommand;
 import cmc.delta.domain.auth.application.port.in.provisioning.UserProvisioningUseCase;
 import cmc.delta.domain.auth.application.port.out.SocialAccountRepositoryPort;
@@ -8,11 +13,8 @@ import cmc.delta.domain.auth.model.SocialAccount;
 import cmc.delta.domain.user.application.exception.UserException;
 import cmc.delta.domain.user.application.port.out.UserRepositoryPort;
 import cmc.delta.domain.user.model.User;
+import cmc.delta.global.config.WebhookConfig;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +23,7 @@ public class UserProvisioningServiceImpl implements UserProvisioningUseCase {
 	private final UserRepositoryPort userRepositoryPort;
 	private final SocialAccountRepositoryPort socialAccountRepositoryPort;
 	private final SocialUserProvisionValidator validator;
+	private final WebhookConfig webhookConfig;
 
 	@Override
 	@Transactional
@@ -48,6 +51,7 @@ public class UserProvisioningServiceImpl implements UserProvisioningUseCase {
 
 	private ProvisioningResult createAndLink(SocialUserProvisionCommand command) {
 		User user = userRepositoryPort.save(User.createProvisioned(command.email(), command.nickname()));
+		webhookConfig.sendDiscordNotification(user.getId());
 		SocialAccount account = SocialAccount.link(command.provider(), command.providerUserId(), user);
 		socialAccountRepositoryPort.save(account);
 		return new ProvisioningResult(user.getId(), user.getEmail(), user.getNickname(), true);

--- a/src/main/java/cmc/delta/domain/auth/application/service/social/SocialAuthService.java
+++ b/src/main/java/cmc/delta/domain/auth/application/service/social/SocialAuthService.java
@@ -1,14 +1,17 @@
 package cmc.delta.domain.auth.application.service.social;
 
+import java.time.Duration;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
 import cmc.delta.domain.auth.adapter.out.oauth.loginkey.RedisLoginKeyStore;
 import cmc.delta.domain.auth.application.exception.SocialAuthException;
 import cmc.delta.domain.auth.application.port.in.loginkey.LoginKeyExchangeUseCase;
+import cmc.delta.domain.auth.application.port.in.social.SocialLoginCommandUseCase;
 import cmc.delta.domain.auth.application.support.FrontendDefaults;
 import cmc.delta.global.config.FrontendProperties;
-import java.time.Duration;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -19,9 +22,7 @@ public class SocialAuthService {
 	private final LoginKeyExchangeUseCase loginKeyExchangeUseCase;
 	private final FrontendProperties frontendProperties;
 
-	public String createLoginKeyAndBuildRedirect(
-		cmc.delta.domain.auth.application.port.in.social.SocialLoginCommandUseCase.LoginResult result,
-		Duration ttl) {
+	public String createLoginKeyAndBuildRedirect(SocialLoginCommandUseCase.LoginResult result, Duration ttl) {
 		String loginKey = UUID.randomUUID().toString();
 		loginKeyExchangeUseCase.save(loginKey, result.data(), result.tokens(), ttl);
 

--- a/src/main/java/cmc/delta/domain/problem/adapter/in/worker/ScanPurgeWorker.java
+++ b/src/main/java/cmc/delta/domain/problem/adapter/in/worker/ScanPurgeWorker.java
@@ -37,7 +37,7 @@ public class ScanPurgeWorker extends AbstractExternalCallScanWorker {
 	private final PurgeWorkerProperties properties;
 	private final ScanPurgePersister persister;
 
-	private volatile int lastRetentionDays;
+	private static final ThreadLocal<Integer> retentionDaysHolder = new ThreadLocal<>();
 
 	public ScanPurgeWorker(
 		Clock clock,
@@ -61,18 +61,21 @@ public class ScanPurgeWorker extends AbstractExternalCallScanWorker {
 		this.problemRepository = problemRepository;
 		this.properties = properties;
 		this.persister = persister;
-		this.lastRetentionDays = properties.retentionDays();
 	}
 
 	public void runBatch(String lockOwner, int batchSize, long lockLeaseSeconds, int retentionDays) {
-		this.lastRetentionDays = retentionDays;
-		super.runBatch(lockOwner, batchSize, lockLeaseSeconds);
+		retentionDaysHolder.set(retentionDays);
+		try {
+			super.runBatch(lockOwner, batchSize, lockLeaseSeconds);
+		} finally {
+			retentionDaysHolder.remove();
+		}
 	}
 
 	@Override
 	protected int claim(LocalDateTime now, LocalDateTime staleBefore, String lockOwner, String lockToken,
 		LocalDateTime lockedAt, int limit) {
-		LocalDateTime cutoffCreatedAt = now.minusDays(lastRetentionDays);
+		LocalDateTime cutoffCreatedAt = now.minusDays(currentRetentionDays());
 		return scanWorkRepository.claimPurgeCandidates(cutoffCreatedAt, staleBefore, lockOwner, lockToken, lockedAt,
 			limit);
 	}
@@ -89,8 +92,13 @@ public class ScanPurgeWorker extends AbstractExternalCallScanWorker {
 
 	@Override
 	protected long countBacklog(LocalDateTime now, LocalDateTime staleBefore) {
-		LocalDateTime cutoffCreatedAt = now.minusDays(lastRetentionDays);
+		LocalDateTime cutoffCreatedAt = now.minusDays(currentRetentionDays());
 		return scanWorkRepository.countPurgeBacklog(cutoffCreatedAt, staleBefore);
+	}
+
+	private int currentRetentionDays() {
+		Integer days = retentionDaysHolder.get();
+		return days != null ? days : properties.retentionDays();
 	}
 
 	@Override

--- a/src/main/java/cmc/delta/domain/problem/adapter/in/worker/scheduler/ProblemKeyBackfillScheduler.java
+++ b/src/main/java/cmc/delta/domain/problem/adapter/in/worker/scheduler/ProblemKeyBackfillScheduler.java
@@ -1,25 +1,29 @@
-package cmc.delta.domain.problem.adapter.in.worker.scheduler;
+// package cmc.delta.domain.problem.adapter.in.worker.scheduler;
+//
+// import cmc.delta.domain.problem.adapter.in.worker.ProblemKeyBackfillWorker;
+// import cmc.delta.domain.problem.adapter.in.worker.properties.ProblemKeyBackfillWorkerProperties;
+// import lombok.RequiredArgsConstructor;
+// import lombok.extern.slf4j.Slf4j;
+// import org.springframework.scheduling.annotation.Scheduled;
+// import org.springframework.stereotype.Component;
+//
+// @Slf4j
+// @Component
+// @RequiredArgsConstructor
+// public class ProblemKeyBackfillScheduler {
+//
+// 	private final ProblemKeyBackfillWorker worker;
+// 	private final ProblemKeyBackfillWorkerProperties props;
+//
+// 	@Scheduled(fixedDelayString = "${worker.problem-key-backfill.fixed-delay-ms:600000}")
+// 	public void tick() {
+// 		int processed = worker.runOnce(props.batchSize());
+// 		if (processed > 0) {
+// 			log.debug("problem key backfill tick processed={}", processed);
+// 		}
+// 	}
+// }
 
-import cmc.delta.domain.problem.adapter.in.worker.ProblemKeyBackfillWorker;
-import cmc.delta.domain.problem.adapter.in.worker.properties.ProblemKeyBackfillWorkerProperties;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-
-@Slf4j
-@Component
-@RequiredArgsConstructor
-public class ProblemKeyBackfillScheduler {
-
-	private final ProblemKeyBackfillWorker worker;
-	private final ProblemKeyBackfillWorkerProperties props;
-
-	@Scheduled(fixedDelayString = "${worker.problem-key-backfill.fixed-delay-ms:600000}")
-	public void tick() {
-		int processed = worker.runOnce(props.batchSize());
-		if (processed > 0) {
-			log.debug("problem key backfill tick processed={}", processed);
-		}
-	}
-}
+/**
+ * 이제 사용하지 않을 예정임, 곧 삭제 예정
+ */

--- a/src/main/java/cmc/delta/domain/problem/adapter/out/ai/gemini/GeminiAiClient.java
+++ b/src/main/java/cmc/delta/domain/problem/adapter/out/ai/gemini/GeminiAiClient.java
@@ -56,7 +56,7 @@ public class GeminiAiClient implements AiClient {
 			Map<String, Object> requestBody = buildRequestBody(promptText);
 			String rawResponseJson = callApi(requestBody);
 			AiCurriculumResult result = parseResponse(rawResponseJson);
-			log.info("Gemini 분류 완료 model={} durationMs={}", props.model(), elapsedMillis(startedAtNanos));
+			log.debug("Gemini 분류 완료 model={} durationMs={}", props.model(), elapsedMillis(startedAtNanos));
 			return result;
 		} catch (RestClientResponseException e) {
 			log.warn("Gemini 분류 HTTP 실패 model={} status={} durationMs={}",

--- a/src/main/java/cmc/delta/domain/user/adapter/out/persistence/UserRepositoryAdapter.java
+++ b/src/main/java/cmc/delta/domain/user/adapter/out/persistence/UserRepositoryAdapter.java
@@ -1,12 +1,14 @@
 package cmc.delta.domain.user.adapter.out.persistence;
 
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
 import cmc.delta.domain.user.adapter.out.persistence.jpa.UserJpaRepository;
 import cmc.delta.domain.user.application.port.out.UserRepositoryPort;
 import cmc.delta.domain.user.model.User;
 import jakarta.persistence.EntityManager;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -33,5 +35,10 @@ public class UserRepositoryAdapter implements UserRepositoryPort {
 	@Override
 	public void delete(User user) {
 		jpaRepository.delete(user);
+	}
+
+	@Override
+	public long count() {
+		return jpaRepository.count();
 	}
 }

--- a/src/main/java/cmc/delta/domain/user/application/port/out/UserRepositoryPort.java
+++ b/src/main/java/cmc/delta/domain/user/application/port/out/UserRepositoryPort.java
@@ -1,7 +1,8 @@
 package cmc.delta.domain.user.application.port.out;
 
-import cmc.delta.domain.user.model.User;
 import java.util.Optional;
+
+import cmc.delta.domain.user.model.User;
 
 public interface UserRepositoryPort {
 	Optional<User> findById(Long id);
@@ -11,4 +12,6 @@ public interface UserRepositoryPort {
 	User getReferenceById(Long id);
 
 	void delete(User user);
+
+	long count();
 }

--- a/src/main/java/cmc/delta/global/config/RestTemplateConfig.java
+++ b/src/main/java/cmc/delta/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package cmc.delta.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/src/main/java/cmc/delta/global/config/WebhookConfig.java
+++ b/src/main/java/cmc/delta/global/config/WebhookConfig.java
@@ -1,0 +1,35 @@
+package cmc.delta.global.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class WebhookConfig {
+
+	@Value("${discord.webhook.bot_toekn_url}")
+	private String discordBotTokenUrl;
+	private final RestTemplate restTemplate;
+
+	public void sendDiscordNotification(Long userId) {
+		String message = "Semo에 " + userId + "번째 유저가 가입했습니다!🎉";
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+
+		Map<String, String> body = new HashMap<>();
+		body.put("content", message);
+
+		HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(body, headers);
+		restTemplate.postForEntity(discordBotTokenUrl, requestEntity, String.class);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,3 +62,8 @@ worker:
   ai-solution:
     fixed-delay-ms: ${WORKER_AI_SOLUTION_FIXED_DELAY_MS:2000}
     batch-size: ${WORKER_AI_SOLUTION_BATCH_SIZE:3}
+
+discord:
+  webhook:
+    bot_toekn_url: ${DISCORD_BOT_TOKEN}
+

--- a/src/test/java/cmc/delta/domain/problem/application/command/AiScanPersistCommandServiceTest.java
+++ b/src/test/java/cmc/delta/domain/problem/application/command/AiScanPersistCommandServiceTest.java
@@ -1,0 +1,174 @@
+package cmc.delta.domain.problem.application.command;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import cmc.delta.domain.problem.adapter.in.worker.support.failure.FailureDecision;
+import cmc.delta.domain.problem.adapter.in.worker.support.failure.FailureReason;
+import cmc.delta.domain.problem.adapter.in.worker.support.persistence.AiScanPersister;
+import cmc.delta.domain.problem.application.command.support.TypeCandidatesParser;
+import cmc.delta.domain.problem.application.command.support.TypeCandidatesParser.TypeCandidate;
+import cmc.delta.domain.problem.application.port.out.ai.dto.AiCurriculumResult;
+import cmc.delta.domain.problem.application.port.out.prediction.ScanTypePredictionWriter;
+import cmc.delta.domain.problem.application.port.out.prediction.ScanTypePredictionWriter.TypePrediction;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AiScanPersistCommandServiceTest {
+
+	private AiScanPersister persister;
+	private ScanTypePredictionWriter predictionWriter;
+	private TypeCandidatesParser typeCandidatesParser;
+	private AiScanPersistCommandService sut;
+
+	@BeforeEach
+	void setUp() {
+		persister = mock(AiScanPersister.class);
+		predictionWriter = mock(ScanTypePredictionWriter.class);
+		typeCandidatesParser = mock(TypeCandidatesParser.class);
+		sut = new AiScanPersistCommandService(persister, predictionWriter, typeCandidatesParser);
+	}
+
+	@Test
+	@DisplayName("persistAiSucceeded: JSON 파싱 성공 시 파싱된 candidates로 predictions를 저장한다")
+	void persistAiSucceeded_withParsedCandidates_savesParsedPredictions() {
+		// given
+		Long scanId = 1L;
+		LocalDateTime now = LocalDateTime.of(2026, 1, 1, 0, 0);
+		AiCurriculumResult result = aiResult("T1", 0.9, "[{...}]");
+
+		List<TypeCandidate> parsed = List.of(
+			new TypeCandidate("T1", BigDecimal.valueOf(0.9)),
+			new TypeCandidate("T2", BigDecimal.valueOf(0.7))
+		);
+		when(typeCandidatesParser.parseTypeCandidates(any())).thenReturn(parsed);
+
+		// when
+		sut.persistAiSucceeded(scanId, "owner", "token", result, now);
+
+		// then
+		ArgumentCaptor<List<TypePrediction>> captor = ArgumentCaptor.forClass(List.class);
+		verify(predictionWriter).replacePredictions(eq(scanId), captor.capture());
+
+		List<TypePrediction> saved = captor.getValue();
+		assertThat(saved).hasSize(2);
+		assertThat(saved.get(0).typeId()).isEqualTo("T1");
+		assertThat(saved.get(0).rankNo()).isEqualTo(1);
+		assertThat(saved.get(1).typeId()).isEqualTo("T2");
+		assertThat(saved.get(1).rankNo()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("persistAiSucceeded: JSON 파싱 결과가 비어있으면 predictedTypeId로 fallback된다")
+	void persistAiSucceeded_whenParsedEmpty_fallbackToPredictedTypeId() {
+		// given
+		Long scanId = 2L;
+		LocalDateTime now = LocalDateTime.of(2026, 1, 1, 0, 0);
+		AiCurriculumResult result = aiResult("FALLBACK-TYPE", 0.75, "[]");
+
+		when(typeCandidatesParser.parseTypeCandidates(any())).thenReturn(List.of());
+
+		// when
+		sut.persistAiSucceeded(scanId, "owner", "token", result, now);
+
+		// then
+		ArgumentCaptor<List<TypePrediction>> captor = ArgumentCaptor.forClass(List.class);
+		verify(predictionWriter).replacePredictions(eq(scanId), captor.capture());
+
+		List<TypePrediction> saved = captor.getValue();
+		assertThat(saved).hasSize(1);
+		assertThat(saved.get(0).typeId()).isEqualTo("FALLBACK-TYPE");
+		assertThat(saved.get(0).rankNo()).isEqualTo(1);
+		assertThat(saved.get(0).confidence()).isEqualByComparingTo(BigDecimal.valueOf(0.75));
+	}
+
+	@Test
+	@DisplayName("persistAiSucceeded: JSON 파싱 결과가 비어있고 predictedTypeId도 null이면 빈 predictions를 저장한다")
+	void persistAiSucceeded_whenParsedEmptyAndNullTypeId_savesEmpty() {
+		// given
+		Long scanId = 3L;
+		LocalDateTime now = LocalDateTime.of(2026, 1, 1, 0, 0);
+		AiCurriculumResult result = aiResultWithNullTypeId(0.5, "[]");
+
+		when(typeCandidatesParser.parseTypeCandidates(any())).thenReturn(List.of());
+
+		// when
+		sut.persistAiSucceeded(scanId, "owner", "token", result, now);
+
+		// then
+		ArgumentCaptor<List<TypePrediction>> captor = ArgumentCaptor.forClass(List.class);
+		verify(predictionWriter).replacePredictions(eq(scanId), captor.capture());
+		assertThat(captor.getValue()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("persistAiSucceeded: JSON 파싱 결과가 비어있고 predictedTypeId가 blank이면 빈 predictions를 저장한다")
+	void persistAiSucceeded_whenParsedEmptyAndBlankTypeId_savesEmpty() {
+		// given
+		Long scanId = 4L;
+		LocalDateTime now = LocalDateTime.of(2026, 1, 1, 0, 0);
+		AiCurriculumResult result = new AiCurriculumResult(
+			true, null, null, "   ", 0.5, null, null, "[]", null);
+
+		when(typeCandidatesParser.parseTypeCandidates(any())).thenReturn(List.of());
+
+		// when
+		sut.persistAiSucceeded(scanId, "owner", "token", result, now);
+
+		// then
+		ArgumentCaptor<List<TypePrediction>> captor = ArgumentCaptor.forClass(List.class);
+		verify(predictionWriter).replacePredictions(eq(scanId), captor.capture());
+		assertThat(captor.getValue()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("persistAiSucceeded: persister.persistAiSucceeded를 반드시 먼저 호출한다")
+	void persistAiSucceeded_callsPersisterFirst() {
+		// given
+		Long scanId = 5L;
+		LocalDateTime now = LocalDateTime.of(2026, 1, 1, 0, 0);
+		AiCurriculumResult result = aiResult("T1", 0.9, null);
+
+		when(typeCandidatesParser.parseTypeCandidates(any())).thenReturn(List.of());
+
+		// when
+		sut.persistAiSucceeded(scanId, "owner", "token", result, now);
+
+		// then
+		var inOrder = inOrder(persister, predictionWriter);
+		inOrder.verify(persister).persistAiSucceeded(eq(scanId), eq("owner"), eq("token"), eq(result), eq(now));
+		inOrder.verify(predictionWriter).replacePredictions(eq(scanId), any());
+	}
+
+	@Test
+	@DisplayName("persistAiFailed: persister에 그대로 위임한다")
+	void persistAiFailed_delegatesToPersister() {
+		// given
+		Long scanId = 6L;
+		LocalDateTime now = LocalDateTime.of(2026, 1, 1, 0, 0);
+		FailureDecision decision = FailureDecision.retryable(FailureReason.SCAN_NOT_FOUND);
+
+		// when
+		sut.persistAiFailed(scanId, "owner", "token", decision, now);
+
+		// then
+		verify(persister).persistAiFailed(scanId, "owner", "token", decision, now);
+		verifyNoInteractions(predictionWriter);
+	}
+
+	private AiCurriculumResult aiResult(String typeId, double confidence, String typeCandidatesJson) {
+		return new AiCurriculumResult(
+			true, null, null, typeId, confidence, null, null, typeCandidatesJson, null);
+	}
+
+	private AiCurriculumResult aiResultWithNullTypeId(double confidence, String typeCandidatesJson) {
+		return new AiCurriculumResult(
+			true, null, null, null, confidence, null, null, typeCandidatesJson, null);
+	}
+}

--- a/src/test/java/cmc/delta/domain/problem/application/command/ScanTypePredictionCommandServiceTest.java
+++ b/src/test/java/cmc/delta/domain/problem/application/command/ScanTypePredictionCommandServiceTest.java
@@ -1,0 +1,151 @@
+package cmc.delta.domain.problem.application.command;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import cmc.delta.domain.problem.application.command.ScanTypePredictionCommandService.PredictedType;
+import cmc.delta.domain.problem.application.port.out.prediction.ScanTypePredictionWriter;
+import cmc.delta.domain.problem.application.port.out.prediction.ScanTypePredictionWriter.TypePrediction;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ScanTypePredictionCommandServiceTest {
+
+	private ScanTypePredictionWriter predictionWriter;
+	private ScanTypePredictionCommandService sut;
+
+	@BeforeEach
+	void setUp() {
+		predictionWriter = mock(ScanTypePredictionWriter.class);
+		sut = new ScanTypePredictionCommandService(predictionWriter);
+	}
+
+	@Test
+	@DisplayName("replacePredictedTypes: rank는 1부터 순서대로 부여된다")
+	void replacePredictedTypes_rankStartsAtOne() {
+		// given
+		Long scanId = 1L;
+		List<PredictedType> input = List.of(
+			new PredictedType("T1", BigDecimal.valueOf(0.9)),
+			new PredictedType("T2", BigDecimal.valueOf(0.7)),
+			new PredictedType("T3", BigDecimal.valueOf(0.5))
+		);
+
+		// when
+		sut.replacePredictedTypes(scanId, input);
+
+		// then
+		ArgumentCaptor<List<TypePrediction>> captor = ArgumentCaptor.forClass(List.class);
+		verify(predictionWriter).replacePredictions(eq(scanId), captor.capture());
+
+		List<TypePrediction> saved = captor.getValue();
+		assertThat(saved).hasSize(3);
+		assertThat(saved.get(0).rankNo()).isEqualTo(1);
+		assertThat(saved.get(1).rankNo()).isEqualTo(2);
+		assertThat(saved.get(2).rankNo()).isEqualTo(3);
+	}
+
+	@Test
+	@DisplayName("replacePredictedTypes: typeId와 confidence가 그대로 전달된다")
+	void replacePredictedTypes_preservesTypeIdAndConfidence() {
+		// given
+		Long scanId = 2L;
+		BigDecimal confidence = BigDecimal.valueOf(0.85);
+		List<PredictedType> input = List.of(new PredictedType("TYPE-A", confidence));
+
+		// when
+		sut.replacePredictedTypes(scanId, input);
+
+		// then
+		ArgumentCaptor<List<TypePrediction>> captor = ArgumentCaptor.forClass(List.class);
+		verify(predictionWriter).replacePredictions(eq(scanId), captor.capture());
+
+		TypePrediction saved = captor.getValue().get(0);
+		assertThat(saved.typeId()).isEqualTo("TYPE-A");
+		assertThat(saved.confidence()).isEqualByComparingTo(confidence);
+	}
+
+	@Test
+	@DisplayName("replacePredictedTypes: 5개 초과 입력 시 상위 5개만 저장된다")
+	void replacePredictedTypes_limitsToFive() {
+		// given
+		Long scanId = 3L;
+		List<PredictedType> input = List.of(
+			new PredictedType("T1", BigDecimal.valueOf(0.9)),
+			new PredictedType("T2", BigDecimal.valueOf(0.8)),
+			new PredictedType("T3", BigDecimal.valueOf(0.7)),
+			new PredictedType("T4", BigDecimal.valueOf(0.6)),
+			new PredictedType("T5", BigDecimal.valueOf(0.5)),
+			new PredictedType("T6", BigDecimal.valueOf(0.4))  // 6번째 → 잘려야 함
+		);
+
+		// when
+		sut.replacePredictedTypes(scanId, input);
+
+		// then
+		ArgumentCaptor<List<TypePrediction>> captor = ArgumentCaptor.forClass(List.class);
+		verify(predictionWriter).replacePredictions(eq(scanId), captor.capture());
+
+		List<TypePrediction> saved = captor.getValue();
+		assertThat(saved).hasSize(5);
+		assertThat(saved).extracting(TypePrediction::typeId)
+			.containsExactly("T1", "T2", "T3", "T4", "T5");
+	}
+
+	@Test
+	@DisplayName("replacePredictedTypes: 정확히 5개이면 전부 저장된다")
+	void replacePredictedTypes_exactlyFiveIsNotTrimmed() {
+		// given
+		Long scanId = 4L;
+		List<PredictedType> input = List.of(
+			new PredictedType("T1", BigDecimal.valueOf(0.9)),
+			new PredictedType("T2", BigDecimal.valueOf(0.8)),
+			new PredictedType("T3", BigDecimal.valueOf(0.7)),
+			new PredictedType("T4", BigDecimal.valueOf(0.6)),
+			new PredictedType("T5", BigDecimal.valueOf(0.5))
+		);
+
+		// when
+		sut.replacePredictedTypes(scanId, input);
+
+		// then
+		ArgumentCaptor<List<TypePrediction>> captor = ArgumentCaptor.forClass(List.class);
+		verify(predictionWriter).replacePredictions(eq(scanId), captor.capture());
+		assertThat(captor.getValue()).hasSize(5);
+	}
+
+	@Test
+	@DisplayName("replacePredictedTypes: 빈 리스트 입력 시 빈 리스트로 replacePredictions가 호출된다")
+	void replacePredictedTypes_emptyList_callsWriterWithEmpty() {
+		// given
+		Long scanId = 5L;
+
+		// when
+		sut.replacePredictedTypes(scanId, List.of());
+
+		// then
+		ArgumentCaptor<List<TypePrediction>> captor = ArgumentCaptor.forClass(List.class);
+		verify(predictionWriter).replacePredictions(eq(scanId), captor.capture());
+		assertThat(captor.getValue()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("replacePredictedTypes: null 입력 시 빈 리스트로 replacePredictions가 호출된다")
+	void replacePredictedTypes_nullList_callsWriterWithEmpty() {
+		// given
+		Long scanId = 6L;
+
+		// when
+		sut.replacePredictedTypes(scanId, null);
+
+		// then
+		ArgumentCaptor<List<TypePrediction>> captor = ArgumentCaptor.forClass(List.class);
+		verify(predictionWriter).replacePredictions(eq(scanId), captor.capture());
+		assertThat(captor.getValue()).isEmpty();
+	}
+}

--- a/src/test/java/cmc/delta/domain/problem/application/validation/command/ProblemCreateCurriculumValidatorTest.java
+++ b/src/test/java/cmc/delta/domain/problem/application/validation/command/ProblemCreateCurriculumValidatorTest.java
@@ -1,0 +1,201 @@
+package cmc.delta.domain.problem.application.validation.command;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import cmc.delta.domain.curriculum.application.port.out.ProblemTypeLoadPort;
+import cmc.delta.domain.curriculum.application.port.out.UnitLoadPort;
+import cmc.delta.domain.curriculum.model.ProblemType;
+import cmc.delta.domain.curriculum.model.Unit;
+import cmc.delta.domain.problem.application.exception.ProblemException;
+import cmc.delta.global.error.ErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ProblemCreateCurriculumValidatorTest {
+
+	private UnitLoadPort unitLoadPort;
+	private ProblemTypeLoadPort typeLoadPort;
+	private ProblemCreateCurriculumValidator sut;
+
+	@BeforeEach
+	void setUp() {
+		unitLoadPort = mock(UnitLoadPort.class);
+		typeLoadPort = mock(ProblemTypeLoadPort.class);
+		sut = new ProblemCreateCurriculumValidator(typeLoadPort, unitLoadPort);
+	}
+
+	// ── getFinalUnit ──────────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("getFinalUnit: 부모 있는 unit이면 반환한다")
+	void getFinalUnit_whenUnitHasParent_returnsUnit() {
+		// given
+		Unit parent = unitWithId("PARENT");
+		Unit leaf = unitWithParent("LEAF", parent);
+		when(unitLoadPort.findById("LEAF")).thenReturn(Optional.of(leaf));
+
+		// when
+		Unit result = sut.getFinalUnit("LEAF");
+
+		// then
+		assertThat(result).isSameAs(leaf);
+	}
+
+	@Test
+	@DisplayName("getFinalUnit: unit이 존재하지 않으면 PROBLEM_FINAL_UNIT_NOT_FOUND")
+	void getFinalUnit_whenNotFound_throwsNotFound() {
+		// given
+		when(unitLoadPort.findById("X")).thenReturn(Optional.empty());
+
+		// when
+		ProblemException ex = catchThrowableOfType(
+			() -> sut.getFinalUnit("X"),
+			ProblemException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROBLEM_FINAL_UNIT_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("getFinalUnit: 부모 없는 unit(최상위)이면 PROBLEM_FINAL_UNIT_NOT_FOUND")
+	void getFinalUnit_whenNoParent_throwsNotFound() {
+		// given
+		Unit root = unitWithId("ROOT");  // parent == null
+		when(unitLoadPort.findById("ROOT")).thenReturn(Optional.of(root));
+
+		// when
+		ProblemException ex = catchThrowableOfType(
+			() -> sut.getFinalUnit("ROOT"),
+			ProblemException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROBLEM_FINAL_UNIT_NOT_FOUND);
+	}
+
+	// ── getFinalType ──────────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("getFinalType: 존재하는 type이면 반환한다")
+	void getFinalType_whenFound_returnsType() {
+		// given
+		Long userId = 1L;
+		ProblemType type = typeWithId("T1");
+		when(typeLoadPort.findActiveVisibleById(userId, "T1")).thenReturn(Optional.of(type));
+
+		// when
+		ProblemType result = sut.getFinalType(userId, "T1");
+
+		// then
+		assertThat(result).isSameAs(type);
+	}
+
+	@Test
+	@DisplayName("getFinalType: 존재하지 않으면 PROBLEM_FINAL_TYPE_NOT_FOUND")
+	void getFinalType_whenNotFound_throwsNotFound() {
+		// given
+		Long userId = 1L;
+		when(typeLoadPort.findActiveVisibleById(userId, "NONE")).thenReturn(Optional.empty());
+
+		// when
+		ProblemException ex = catchThrowableOfType(
+			() -> sut.getFinalType(userId, "NONE"),
+			ProblemException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROBLEM_FINAL_TYPE_NOT_FOUND);
+	}
+
+	// ── getFinalTypes ─────────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("getFinalTypes: 요청 순서대로 정렬해서 반환한다")
+	void getFinalTypes_reordersToRequestOrder() {
+		// given
+		Long userId = 1L;
+		ProblemType t1 = typeWithId("T1");
+		ProblemType t2 = typeWithId("T2");
+		// DB는 T2, T1 순으로 반환했지만 요청은 T1, T2 순
+		when(typeLoadPort.findActiveVisibleByIds(userId, List.of("T1", "T2"))).thenReturn(List.of(t2, t1));
+
+		// when
+		List<ProblemType> result = sut.getFinalTypes(userId, List.of("T1", "T2"));
+
+		// then
+		assertThat(result).containsExactly(t1, t2);
+	}
+
+	@Test
+	@DisplayName("getFinalTypes: 중복 typeId는 하나로 처리된다")
+	void getFinalTypes_deduplicatesIds() {
+		// given
+		Long userId = 1L;
+		ProblemType t1 = typeWithId("T1");
+		when(typeLoadPort.findActiveVisibleByIds(userId, List.of("T1"))).thenReturn(List.of(t1));
+
+		// when
+		List<ProblemType> result = sut.getFinalTypes(userId, List.of("T1", "T1"));
+
+		// then
+		assertThat(result).hasSize(1).containsExactly(t1);
+	}
+
+	@Test
+	@DisplayName("getFinalTypes: typeIds가 null이면 INVALID_REQUEST")
+	void getFinalTypes_whenNull_throwsInvalidRequest() {
+		// when
+		ProblemException ex = catchThrowableOfType(
+			() -> sut.getFinalTypes(1L, null),
+			ProblemException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("getFinalTypes: typeIds가 비어있으면 INVALID_REQUEST")
+	void getFinalTypes_whenEmpty_throwsInvalidRequest() {
+		// when
+		ProblemException ex = catchThrowableOfType(
+			() -> sut.getFinalTypes(1L, List.of()),
+			ProblemException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("getFinalTypes: 요청한 type 중 일부가 없으면 PROBLEM_FINAL_TYPE_NOT_FOUND")
+	void getFinalTypes_whenSomeNotFound_throwsNotFound() {
+		// given
+		Long userId = 1L;
+		ProblemType t1 = typeWithId("T1");
+		// T2는 반환되지 않음
+		when(typeLoadPort.findActiveVisibleByIds(userId, List.of("T1", "T2"))).thenReturn(List.of(t1));
+
+		// when
+		ProblemException ex = catchThrowableOfType(
+			() -> sut.getFinalTypes(userId, List.of("T1", "T2")),
+			ProblemException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROBLEM_FINAL_TYPE_NOT_FOUND);
+	}
+
+	// ── helpers ───────────────────────────────────────────────────────────────
+
+	private Unit unitWithId(String id) {
+		return new Unit(id, "name-" + id, null, 1, true);
+	}
+
+	private Unit unitWithParent(String id, Unit parent) {
+		return new Unit(id, "name-" + id, parent, 1, true);
+	}
+
+	private ProblemType typeWithId(String id) {
+		return new ProblemType(id, "name-" + id, 1, true, null, false);
+	}
+}

--- a/src/test/java/cmc/delta/domain/problem/application/validation/command/ProblemCreateScanValidatorTest.java
+++ b/src/test/java/cmc/delta/domain/problem/application/validation/command/ProblemCreateScanValidatorTest.java
@@ -1,0 +1,182 @@
+package cmc.delta.domain.problem.application.validation.command;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import cmc.delta.domain.problem.application.exception.ProblemException;
+import cmc.delta.domain.problem.application.exception.ProblemStateException;
+import cmc.delta.domain.problem.application.exception.ProblemValidationException;
+import cmc.delta.domain.problem.application.port.in.support.UploadFile;
+import cmc.delta.domain.problem.application.port.out.problem.ProblemRepositoryPort;
+import cmc.delta.domain.problem.application.port.out.scan.ProblemScanRepositoryPort;
+import cmc.delta.domain.problem.model.enums.ScanStatus;
+import cmc.delta.domain.problem.model.scan.ProblemScan;
+import cmc.delta.global.error.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ProblemCreateScanValidatorTest {
+
+	private ProblemScanRepositoryPort scanRepositoryPort;
+	private ProblemRepositoryPort problemRepositoryPort;
+	private ProblemCreateScanValidator sut;
+
+	@BeforeEach
+	void setUp() {
+		scanRepositoryPort = mock(ProblemScanRepositoryPort.class);
+		problemRepositoryPort = mock(ProblemRepositoryPort.class);
+		sut = new ProblemCreateScanValidator(scanRepositoryPort, problemRepositoryPort);
+	}
+
+	@Test
+	@DisplayName("getOwnedScan: 본인 소유 스캔이면 반환한다")
+	void getOwnedScan_whenOwned_returnsScan() {
+		// given
+		Long userId = 1L;
+		Long scanId = 10L;
+		ProblemScan scan = mock(ProblemScan.class);
+		when(scanRepositoryPort.findOwnedById(scanId, userId)).thenReturn(Optional.of(scan));
+
+		// when
+		ProblemScan result = sut.getOwnedScan(userId, scanId);
+
+		// then
+		assertThat(result).isSameAs(scan);
+	}
+
+	@Test
+	@DisplayName("getOwnedScan: 스캔이 없거나 다른 유저 소유이면 PROBLEM_SCAN_NOT_FOUND")
+	void getOwnedScan_whenNotOwned_throwsScanNotFound() {
+		// given
+		Long userId = 1L;
+		Long scanId = 10L;
+		when(scanRepositoryPort.findOwnedById(scanId, userId)).thenReturn(Optional.empty());
+
+		// when
+		ProblemException ex = catchThrowableOfType(
+			() -> sut.getOwnedScan(userId, scanId),
+			ProblemException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROBLEM_SCAN_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("validateScanIsAiDone: AI_DONE 상태이면 예외 없음")
+	void validateScanIsAiDone_whenAiDone_doesNotThrow() {
+		// given
+		ProblemScan scan = mock(ProblemScan.class);
+		when(scan.getStatus()).thenReturn(ScanStatus.AI_DONE);
+
+		// when/then
+		assertThatCode(() -> sut.validateScanIsAiDone(scan)).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("validateScanIsAiDone: UPLOADED 상태이면 PROBLEM_SCAN_NOT_READY")
+	void validateScanIsAiDone_whenUploaded_throwsNotReady() {
+		// given
+		ProblemScan scan = mock(ProblemScan.class);
+		when(scan.getStatus()).thenReturn(ScanStatus.UPLOADED);
+
+		// when
+		ProblemException ex = catchThrowableOfType(
+			() -> sut.validateScanIsAiDone(scan),
+			ProblemException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROBLEM_SCAN_NOT_READY);
+	}
+
+	@Test
+	@DisplayName("validateScanIsAiDone: OCR_DONE 상태이면 PROBLEM_SCAN_NOT_READY")
+	void validateScanIsAiDone_whenOcrDone_throwsNotReady() {
+		// given
+		ProblemScan scan = mock(ProblemScan.class);
+		when(scan.getStatus()).thenReturn(ScanStatus.OCR_DONE);
+
+		// when
+		ProblemException ex = catchThrowableOfType(
+			() -> sut.validateScanIsAiDone(scan),
+			ProblemException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROBLEM_SCAN_NOT_READY);
+	}
+
+	@Test
+	@DisplayName("validateScanIsAiDone: FAILED 상태이면 PROBLEM_SCAN_NOT_READY")
+	void validateScanIsAiDone_whenFailed_throwsNotReady() {
+		// given
+		ProblemScan scan = mock(ProblemScan.class);
+		when(scan.getStatus()).thenReturn(ScanStatus.FAILED);
+
+		// when
+		ProblemException ex = catchThrowableOfType(
+			() -> sut.validateScanIsAiDone(scan),
+			ProblemException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROBLEM_SCAN_NOT_READY);
+	}
+
+	@Test
+	@DisplayName("validateProblemNotAlreadyCreated: 문제가 없으면 예외 없음")
+	void validateProblemNotAlreadyCreated_whenNotExists_doesNotThrow() {
+		// given
+		Long scanId = 10L;
+		when(problemRepositoryPort.existsByScanId(scanId)).thenReturn(false);
+
+		// when/then
+		assertThatCode(() -> sut.validateProblemNotAlreadyCreated(scanId)).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("validateProblemNotAlreadyCreated: 이미 문제가 생성되어 있으면 PROBLEM_ALREADY_CREATED")
+	void validateProblemNotAlreadyCreated_whenExists_throwsAlreadyCreated() {
+		// given
+		Long scanId = 10L;
+		when(problemRepositoryPort.existsByScanId(scanId)).thenReturn(true);
+
+		// when
+		ProblemStateException ex = catchThrowableOfType(
+			() -> sut.validateProblemNotAlreadyCreated(scanId),
+			ProblemStateException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROBLEM_ALREADY_CREATED);
+	}
+
+	@Test
+	@DisplayName("validateFileNotEmpty: 파일이 있으면 예외 없음")
+	void validateFileNotEmpty_whenFilePresent_doesNotThrow() {
+		// given
+		UploadFile file = mock(UploadFile.class);
+		when(file.isEmpty()).thenReturn(false);
+
+		// when/then
+		assertThatCode(() -> sut.validateFileNotEmpty(file)).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("validateFileNotEmpty: 파일이 null이면 ProblemValidationException")
+	void validateFileNotEmpty_whenNull_throwsValidation() {
+		// when/then
+		assertThatThrownBy(() -> sut.validateFileNotEmpty(null))
+			.isInstanceOf(ProblemValidationException.class);
+	}
+
+	@Test
+	@DisplayName("validateFileNotEmpty: 파일이 비어있으면 ProblemValidationException")
+	void validateFileNotEmpty_whenEmpty_throwsValidation() {
+		// given
+		UploadFile file = mock(UploadFile.class);
+		when(file.isEmpty()).thenReturn(true);
+
+		// when/then
+		assertThatThrownBy(() -> sut.validateFileNotEmpty(file))
+			.isInstanceOf(ProblemValidationException.class);
+	}
+}

--- a/src/test/java/cmc/delta/global/storage/support/StorageRequestValidatorTest.java
+++ b/src/test/java/cmc/delta/global/storage/support/StorageRequestValidatorTest.java
@@ -1,0 +1,224 @@
+package cmc.delta.global.storage.support;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import cmc.delta.global.storage.exception.StorageException;
+import cmc.delta.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+class StorageRequestValidatorTest {
+
+	private StorageRequestValidator sut;
+
+	@BeforeEach
+	void setUp() {
+		sut = new StorageRequestValidator();
+	}
+
+	@Test
+	@DisplayName("validateUploadFile: 정상 파일이면 예외 없음")
+	void validateUploadFile_whenValid_doesNotThrow() {
+		// given
+		MockMultipartFile file = new MockMultipartFile("f", "img.jpg", "image/jpeg", new byte[100]);
+
+		// when/then
+		assertThatCode(() -> sut.validateUploadFile(file, 1024)).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("validateUploadFile: 파일이 null이면 INVALID_REQUEST")
+	void validateUploadFile_whenNull_throwsInvalidRequest() {
+		// when
+		StorageException ex = catchThrowableOfType(
+			() -> sut.validateUploadFile(null, 1024),
+			StorageException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("validateUploadFile: 파일이 비어있으면 INVALID_REQUEST")
+	void validateUploadFile_whenEmpty_throwsInvalidRequest() {
+		// given
+		MockMultipartFile file = new MockMultipartFile("f", "img.jpg", "image/jpeg", new byte[0]);
+
+		// when
+		StorageException ex = catchThrowableOfType(
+			() -> sut.validateUploadFile(file, 1024),
+			StorageException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("validateUploadFile: 파일 크기가 maxUploadBytes를 초과하면 INVALID_REQUEST")
+	void validateUploadFile_whenExceedsMaxBytes_throwsInvalidRequest() {
+		// given
+		MockMultipartFile file = new MockMultipartFile("f", "img.jpg", "image/jpeg", new byte[1025]);
+
+		// when
+		StorageException ex = catchThrowableOfType(
+			() -> sut.validateUploadFile(file, 1024),
+			StorageException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("validateUploadFile: 파일 크기가 정확히 maxUploadBytes이면 예외 없음")
+	void validateUploadFile_whenExactMaxBytes_doesNotThrow() {
+		// given
+		MockMultipartFile file = new MockMultipartFile("f", "img.jpg", "image/jpeg", new byte[1024]);
+
+		// when/then
+		assertThatCode(() -> sut.validateUploadFile(file, 1024)).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("validateUploadFile: maxUploadBytes가 0 이하이면 INTERNAL_ERROR")
+	void validateUploadFile_whenMaxBytesZero_throwsInternalError() {
+		// given
+		MockMultipartFile file = new MockMultipartFile("f", "img.jpg", "image/jpeg", new byte[1]);
+
+		// when
+		StorageException ex = catchThrowableOfType(
+			() -> sut.validateUploadFile(file, 0),
+			StorageException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INTERNAL_ERROR);
+	}
+
+	@Test
+	@DisplayName("validateStorageKey: 정상 key이면 예외 없음")
+	void validateStorageKey_whenValid_doesNotThrow() {
+		assertThatCode(() -> sut.validateStorageKey("uploads/user/image.jpg")).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("validateStorageKey: null이면 INVALID_REQUEST")
+	void validateStorageKey_whenNull_throwsInvalidRequest() {
+		StorageException ex = catchThrowableOfType(
+			() -> sut.validateStorageKey(null),
+			StorageException.class);
+
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("validateStorageKey: 빈 문자열이면 INVALID_REQUEST")
+	void validateStorageKey_whenBlank_throwsInvalidRequest() {
+		StorageException ex = catchThrowableOfType(
+			() -> sut.validateStorageKey("   "),
+			StorageException.class);
+
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("validateStorageKey: '..' 포함 시 경로 탐색 공격 차단 - INVALID_REQUEST")
+	void validateStorageKey_whenPathTraversal_throwsInvalidRequest() {
+		StorageException ex = catchThrowableOfType(
+			() -> sut.validateStorageKey("uploads/../secret/file.jpg"),
+			StorageException.class);
+
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("validateStorageKey: 백슬래시 포함 시 경로 조작 차단 - INVALID_REQUEST")
+	void validateStorageKey_whenBackslash_throwsInvalidRequest() {
+		StorageException ex = catchThrowableOfType(
+			() -> sut.validateStorageKey("uploads\\secret\\file.jpg"),
+			StorageException.class);
+
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	// ── resolveTtlSeconds ─────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("resolveTtlSeconds: null 입력 시 defaultTtlSeconds 반환")
+	void resolveTtlSeconds_whenNull_returnsDefault() {
+		int result = sut.resolveTtlSeconds(null, 3600);
+
+		assertThat(result).isEqualTo(3600);
+	}
+
+	@Test
+	@DisplayName("resolveTtlSeconds: 값 입력 시 해당 값 반환")
+	void resolveTtlSeconds_whenProvided_returnsGiven() {
+		int result = sut.resolveTtlSeconds(120, 3600);
+
+		assertThat(result).isEqualTo(120);
+	}
+
+	@Test
+	@DisplayName("resolveTtlSeconds: 60 미만이면 INVALID_REQUEST")
+	void resolveTtlSeconds_whenBelowMin_throwsInvalidRequest() {
+		StorageException ex = catchThrowableOfType(
+			() -> sut.resolveTtlSeconds(59, 3600),
+			StorageException.class);
+
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("resolveTtlSeconds: 정확히 60이면 예외 없음")
+	void resolveTtlSeconds_whenExactMin_doesNotThrow() {
+		assertThatCode(() -> sut.resolveTtlSeconds(60, 3600)).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("resolveTtlSeconds: default가 60 미만이면 INVALID_REQUEST")
+	void resolveTtlSeconds_whenDefaultBelowMin_throwsInvalidRequest() {
+		StorageException ex = catchThrowableOfType(
+			() -> sut.resolveTtlSeconds(null, 30),
+			StorageException.class);
+
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("validateUploadBytes: 정상 바이트이면 예외 없음")
+	void validateUploadBytes_whenValid_doesNotThrow() {
+		assertThatCode(() -> sut.validateUploadBytes(new byte[]{1, 2, 3}, 1024)).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("validateUploadBytes: null이면 INVALID_REQUEST")
+	void validateUploadBytes_whenNull_throwsInvalidRequest() {
+		StorageException ex = catchThrowableOfType(
+			() -> sut.validateUploadBytes(null, 1024),
+			StorageException.class);
+
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("validateUploadBytes: 비어있는 배열이면 INVALID_REQUEST")
+	void validateUploadBytes_whenEmpty_throwsInvalidRequest() {
+		StorageException ex = catchThrowableOfType(
+			() -> sut.validateUploadBytes(new byte[0], 1024),
+			StorageException.class);
+
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	@DisplayName("validateUploadBytes: maxBytes 초과하면 INVALID_REQUEST")
+	void validateUploadBytes_whenExceedsMax_throwsInvalidRequest() {
+		StorageException ex = catchThrowableOfType(
+			() -> sut.validateUploadBytes(new byte[1025], 1024),
+			StorageException.class);
+
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+	}
+}


### PR DESCRIPTION
## Ⅰ. PR 내용 설명 (Describe what this PR did)
- Discord 회원가입 연동 기능 구현 및 기존 코드와 병합
- Backfill 로직 제거로 불필요한 데이터 처리 로직 정리
- volatile 필드 관련 멀티스레드 안정성 개선 (동시성 이슈 대응)
- Gemini 분류 완료 로그 레벨을 debug로 하향 조정
- 주요 도메인 로직에 대한 테스트 코드 추가
  - ScanTypePrediction / AiScanPersist
  - ProblemCreateValidator / StorageRequestValidator

## Ⅱ. 관련 이슈 (Does this pull request fix one issue?)

## Ⅲ. 검증 방법 (Describe how to verify it)
1. Discord 회원가입 연동 정상 동작 확인
   - 신규 유저 가입 시 Discord 정보 기반으로 계정 생성 여부 확인
2. 기존 회원가입 플로우 영향 여부 확인
3. 멀티스레드 환경에서 volatile 관련 로직 정상 동작 확인
4. 테스트 코드 실행
   - `./gradlew test` 실행 후 전체 테스트 통과 여부 확인
5. 로그 레벨 변경 확인
   - Gemini 분류 완료 로그가 debug 레벨로 출력되는지 확인

## Ⅳ. 리뷰 시 참고 사항 (Special notes for reviews)
- Discord 연동 관련 인증/식별 로직 중심으로 리뷰 부탁드립니다.
- 멀티스레드 관련 변경 부분은 동시성 이슈 방지 관점에서 확인 필요합니다.
- Backfill 제거로 인해 기존 데이터 처리 흐름에 영향 없는지 함께 봐주시면 좋습니다.