### PR TITLE
fix: AI문제풀이 막단에 자신이 쓴 정답이 나오는 오류 수정

### DIFF
--- a/src/main/java/cmc/delta/domain/auth/adapter/out/oauth/token/redis/NoOpAccessBlacklistStore.java
+++ b/src/main/java/cmc/delta/domain/auth/adapter/out/oauth/token/redis/NoOpAccessBlacklistStore.java
@@ -5,17 +5,15 @@ import java.time.Duration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-/** 블랙리스트를 사용하지 않을 때의 기본 구현체다. */
 @Component
 @ConditionalOnProperty(prefix = "jwt.blacklist", name = "enabled", havingValue = "false", matchIfMissing = true)
 public class NoOpAccessBlacklistStore implements AccessBlacklistStore {
-	// 블랙리스트 미사용 시 항상 false로 처리한다.
+
 	@Override
 	public boolean isBlacklisted(String jti) {
 		return false;
 	}
 
-	// 블랙리스트 미사용 시 아무 것도 하지 않는다.
 	@Override
 	public void blacklist(String jti, Duration ttl) {}
 }

--- a/src/main/java/cmc/delta/domain/auth/adapter/out/oauth/token/redis/RedisRefreshTokenStore.java
+++ b/src/main/java/cmc/delta/domain/auth/adapter/out/oauth/token/redis/RedisRefreshTokenStore.java
@@ -49,6 +49,15 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
 	}
 
 	@Override
+	public boolean refreshExists(Long userId, String sessionId, String expectedHash) {
+		if (expectedHash == null || expectedHash.isBlank()) {
+			return false;
+		}
+		String stored = redis.opsForValue().get(key(userId, sessionId));
+		return expectedHash.equals(stored);
+	}
+
+	@Override
 	public void refreshDelete(Long userId, String sessionId) {
 		redis.delete(key(userId, sessionId));
 	}

--- a/src/main/java/cmc/delta/domain/auth/application/port/out/RefreshTokenStore.java
+++ b/src/main/java/cmc/delta/domain/auth/application/port/out/RefreshTokenStore.java
@@ -10,6 +10,8 @@ public interface RefreshTokenStore {
 	RotationResult refreshRotate(
 		Long userId, String sessionId, String expectedHash, String newHash, Duration ttl);
 
+	boolean refreshExists(Long userId, String sessionId, String expectedHash);
+
 	void refreshDelete(Long userId, String sessionId);
 
 	enum RotationResult {

--- a/src/main/java/cmc/delta/domain/auth/application/port/out/TokenIssuer.java
+++ b/src/main/java/cmc/delta/domain/auth/application/port/out/TokenIssuer.java
@@ -9,9 +9,10 @@ public interface TokenIssuer {
 
 	Long extractUserIdFromRefreshToken(String refreshToken);
 
-	String extractJtiFromAccessToken(String accessToken);
+	AccessTokenInfo parseAccessTokenInfo(String accessToken);
 
-	Duration remainingAccessTtl(String accessToken);
+	record AccessTokenInfo(String jti, Duration remainingTtl) {}
+
 
 	record IssuedTokens(String accessToken, String refreshToken, String tokenType) {
 		public String authorizationHeaderValue() {

--- a/src/main/java/cmc/delta/domain/auth/application/service/token/TokenServiceImpl.java
+++ b/src/main/java/cmc/delta/domain/auth/application/service/token/TokenServiceImpl.java
@@ -88,13 +88,8 @@ public class TokenServiceImpl implements TokenCommandUseCase {
 
 	private void validateRefreshTokenMatchOrThrow(long userId, String refreshToken, String action) {
 		String expectedHash = RefreshTokenHasher.sha256(refreshToken);
-		RotationResult check = refreshTokenStore.refreshRotate(
-			userId,
-			DEFAULT_SESSION_ID,
-			expectedHash,
-			expectedHash,
-			DEFAULT_REFRESH_TTL);
-		if (check == RotationResult.MISMATCH) {
+		boolean exists = refreshTokenStore.refreshExists(userId, DEFAULT_SESSION_ID, expectedHash);
+		if (!exists) {
 			auditLogger.refreshMismatch(
 				userId,
 				DEFAULT_SESSION_ID,
@@ -131,12 +126,11 @@ public class TokenServiceImpl implements TokenCommandUseCase {
 		}
 
 		try {
-			String jti = tokenIssuer.extractJtiFromAccessToken(accessTokenOrNull);
-			Duration ttl = tokenIssuer.remainingAccessTtl(accessTokenOrNull);
+			TokenIssuer.AccessTokenInfo info = tokenIssuer.parseAccessTokenInfo(accessTokenOrNull);
 
-			if (ttl != null && !ttl.isNegative() && !ttl.isZero()) {
-				accessBlacklistStore.blacklist(jti, ttl);
-				return BlacklistResult.blacklisted(ttl.getSeconds());
+			if (!info.remainingTtl().isZero()) {
+				accessBlacklistStore.blacklist(info.jti(), info.remainingTtl());
+				return BlacklistResult.blacklisted(info.remainingTtl().getSeconds());
 			}
 			return BlacklistResult.notBlacklisted();
 

--- a/src/main/java/cmc/delta/domain/curriculum/adapter/out/persistence/ProblemTypeLoadJpaAdapter.java
+++ b/src/main/java/cmc/delta/domain/curriculum/adapter/out/persistence/ProblemTypeLoadJpaAdapter.java
@@ -20,6 +20,11 @@ public class ProblemTypeLoadJpaAdapter implements ProblemTypeLoadPort {
 	}
 
 	@Override
+	public List<ProblemType> findByIds(List<String> typeIds) {
+		return repository.findByIdIn(typeIds);
+	}
+
+	@Override
 	public Optional<ProblemType> findActiveVisibleById(Long userId, String typeId) {
 		return repository.findActiveVisibleById(userId, typeId);
 	}

--- a/src/main/java/cmc/delta/domain/curriculum/adapter/out/persistence/jpa/ProblemTypeJpaRepository.java
+++ b/src/main/java/cmc/delta/domain/curriculum/adapter/out/persistence/jpa/ProblemTypeJpaRepository.java
@@ -77,6 +77,8 @@ public interface ProblemTypeJpaRepository extends JpaRepository<ProblemType, Str
 	int findMaxSortOrderVisibleForUser(@Param("userId")
 	Long userId);
 
+	List<ProblemType> findByIdIn(List<String> typeIds);
+
 	@Query("""
 		select t
 		from ProblemType t

--- a/src/main/java/cmc/delta/domain/curriculum/application/port/out/ProblemTypeLoadPort.java
+++ b/src/main/java/cmc/delta/domain/curriculum/application/port/out/ProblemTypeLoadPort.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 public interface ProblemTypeLoadPort {
 	Optional<ProblemType> findById(String typeId);
 
+	List<ProblemType> findByIds(List<String> typeIds);
+
 	Optional<ProblemType> findActiveVisibleById(Long userId, String typeId);
 
 	List<ProblemType> findActiveVisibleByIds(Long userId, List<String> typeIds);

--- a/src/main/java/cmc/delta/domain/problem/adapter/out/ai/CurriculumPromptTemplate.java
+++ b/src/main/java/cmc/delta/domain/problem/adapter/out/ai/CurriculumPromptTemplate.java
@@ -11,25 +11,24 @@ public final class CurriculumPromptTemplate {
 	}
 
 	private static final String TEMPLATE = """
-		너는 한국 고등학교 수학 문제 분류기다.
-		입력 OCR 텍스트를 보고, 아래의 후보 목록 중에서
-		1) 과목(subject)
-		2) 단원(unit)
-		3) 유형(type)
-		을 각각 하나씩 고른다.
+		You are a Korean high school math problem classifier.
+		Given the OCR text below, select one each from the candidate lists:
+		1) subject
+		2) unit
+		3) type
 
-		먼저, 이 OCR 텍스트가 '수학 문제'인지 판단한다.
-		- 수학 문제가 아니면 is_math_problem=false
-		- 수학 문제면 is_math_problem=true
+		First, decide whether the OCR text is a math problem.
+		- If not a math problem: is_math_problem=false
+		- If it is a math problem: is_math_problem=true
 
-		규칙:
-		- 반드시 후보 목록의 id만 사용한다.
-		- 손글씨/낙서로 보이는 부분은 무시하고, 인쇄된 문제 내용 중심으로 판단한다.
-		- 확신이 낮으면 confidence를 낮게 주고, 각 분류마다 후보 3개를 score와 함께 추천한다.
-		- 출력은 반드시 JSON 한 덩어리만 반환한다(설명 문장 금지).
-		- is_math_problem=false인 경우에도 출력 JSON 형식은 유지하되, 분류 id는 빈 문자열로 두고 confidence는 0으로 둔다.
+		Rules:
+		- Use only ids from the candidate lists.
+		- Ignore handwriting or scribbles; focus on the printed problem content.
+		- If confidence is low, set a lower confidence value and recommend 3 candidates per category with scores.
+		- Return exactly one JSON object, no explanation.
+		- If is_math_problem=false, keep the JSON format but set classification ids to empty string and confidence to 0.
 
-		[출력 JSON 형식]
+		[Output JSON format]
 		{
 		  "is_math_problem": true,
 		  "predicted_subject_id": "subject_id",
@@ -41,22 +40,22 @@ public final class CurriculumPromptTemplate {
 		  "type_candidates": [{"id":"...", "score":0.0},{"id":"...", "score":0.0},{"id":"...", "score":0.0}]
 		}
 
-		[후보 과목 목록]
+		[Subject candidates]
 		%s
 
-		[후보 단원 목록]
+		[Unit candidates]
 		%s
 
-		[후보 유형 목록]
+		[Type candidates]
 		%s
 
-		[OCR 구조화 신호]
+		[OCR structured signals]
 		- math_line_count: %d
 		- text_line_count: %d
 		- code_line_count: %d
 		- pseudocode_line_count: %d
 
-		[OCR 텍스트]
+		[OCR text]
 		%s
 		""";
 

--- a/src/main/java/cmc/delta/domain/problem/adapter/out/ai/SolvePromptTemplate.java
+++ b/src/main/java/cmc/delta/domain/problem/adapter/out/ai/SolvePromptTemplate.java
@@ -6,22 +6,22 @@ public final class SolvePromptTemplate {
 	}
 
 	private static final String TEMPLATE = """
-		너는 한국어 수학 문제 풀이 도우미다.
-		입력 이미지의 문제를 읽고 끝까지 완전하게 풀이한다.
+		You are a Korean math problem solver.
+		Read the problem in the input image and solve it completely.
 
-		규칙:
-		- 출력은 반드시 JSON 한 덩어리만 반환한다.
-		- 코드펜스(```)를 절대 쓰지 않는다.
-		- 모든 출력 문자열은 반드시 한국어로 작성한다.
-		- 같은 문장/같은 문단을 반복하지 않는다.
-		- 중간에 가정을 바꾸거나 자기 반박(재검토, 모순 선언, 불가능 선언)을 쓰지 않는다.
-		- solution_latex는 LaTeX 문법만 사용해 핵심 식 전개를 작성한다.
-		- solution_text는 문제 해석, 계산 과정, 결론을 포함하되 수식은 반드시 $...$ 또는 \\(...\\) 형태의 LaTeX 문법으로 작성한다.
-		- final_answer는 반드시 "정답: "으로 시작하는 한 줄로 작성한다.
-		- JSON 문자열 내부 줄바꿈은 반드시 \\n 으로 이스케이프한다.
-		- 불필요한 서론/면책 문구는 쓰지 않는다.
+		Rules:
+		- Return exactly one JSON object, nothing else.
+		- Never use code fences (```).
+		- All output strings must be written in Korean.
+		- Do not repeat the same sentence or paragraph.
+		- Do not change assumptions mid-solution or self-contradict (no re-examination, contradiction, or impossibility declarations).
+		- solution_latex: write only the key equation steps using LaTeX syntax.
+		- solution_text: include problem interpretation, calculation process, and conclusion; all math expressions must use $...$ or \\(...\\) LaTeX syntax.
+		- final_answer: must be a single line starting with "정답: ".
+		- Escape all newlines inside JSON strings as \\n.
+		- No preamble or disclaimer.
 
-		출력 JSON 형식:
+		Output JSON format:
 			{
 			  "solution_latex": "...",
 			  "solution_text": "...",

--- a/src/main/java/cmc/delta/domain/problem/adapter/out/ai/gemini/GeminiProblemSolveAiClient.java
+++ b/src/main/java/cmc/delta/domain/problem/adapter/out/ai/gemini/GeminiProblemSolveAiClient.java
@@ -29,8 +29,8 @@ import lombok.extern.slf4j.Slf4j;
 public class GeminiProblemSolveAiClient implements ProblemSolveAiClient {
 
 	private static final int LOG_TEXT_LIMIT = 1200;
-	private static final int SOLVE_MAX_OUTPUT_TOKENS = 8192;
-	private static final int SOLVE_THINKING_BUDGET = 0;
+	private static final int SOLVE_MAX_OUTPUT_TOKENS = 4096;
+	private static final int SOLVE_THINKING_BUDGET = -1;
 	private static final long NANOS_PER_MILLISECOND = 1_000_000L;
 
 	private static final String PATH_GENERATE_CONTENT = "/v1beta/models/{model}:generateContent";

--- a/src/main/java/cmc/delta/domain/problem/adapter/out/persistence/scan/prediction/ScanTypePredictionPersistenceAdapter.java
+++ b/src/main/java/cmc/delta/domain/problem/adapter/out/persistence/scan/prediction/ScanTypePredictionPersistenceAdapter.java
@@ -9,6 +9,9 @@ import cmc.delta.domain.problem.model.scan.ProblemScan;
 import cmc.delta.domain.problem.model.scan.ProblemScanTypePrediction;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,10 +38,14 @@ public class ScanTypePredictionPersistenceAdapter implements ScanTypePredictionW
 		List<TypePrediction> top = predictions == null ? List.of()
 			: predictions.stream().limit(MAX_PREDICTED_TYPES).toList();
 
+		List<String> typeIds = top.stream().map(TypePrediction::typeId).toList();
+		Map<String, ProblemType> typeMap = problemTypeReader.findByIds(typeIds).stream()
+			.collect(Collectors.toMap(ProblemType::getId, Function.identity()));
+
 		List<ProblemScanTypePrediction> rows = new ArrayList<>();
 		int rank = 1;
 		for (TypePrediction p : top) {
-			ProblemType type = problemTypeReader.findById(p.typeId()).orElse(null);
+			ProblemType type = typeMap.get(p.typeId());
 			if (type == null)
 				continue;
 

--- a/src/main/java/cmc/delta/domain/problem/application/service/command/ProblemAiSolutionCommandServiceImpl.java
+++ b/src/main/java/cmc/delta/domain/problem/application/service/command/ProblemAiSolutionCommandServiceImpl.java
@@ -130,11 +130,7 @@ public class ProblemAiSolutionCommandServiceImpl implements ProblemAiSolutionCom
 			ProblemAiSolvePrompt prompt = new ProblemAiSolvePrompt(imageBytes, imageMimeType, null, null, null);
 			ProblemAiSolveResult solveResult = problemSolveAiClient.solveProblem(prompt);
 
-			String normalizedText = SolutionTextNormalizer.normalize(
-				solveResult.solutionText(),
-				task.getAnswerValue(),
-				task.getAnswerFormat() == null ? null : task.getAnswerFormat().name(),
-				task.getAnswerChoiceNo());
+			String normalizedText = SolutionTextNormalizer.normalize(solveResult.solutionText());
 
 			LocalDateTime completedAt = LocalDateTime.now(clock);
 			task.markReady(solveResult.solutionLatex(), normalizedText, completedAt);

--- a/src/main/java/cmc/delta/domain/problem/application/service/query/ProblemQueryServiceImpl.java
+++ b/src/main/java/cmc/delta/domain/problem/application/service/query/ProblemQueryServiceImpl.java
@@ -1,5 +1,12 @@
 package cmc.delta.domain.problem.application.service.query;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import cmc.delta.domain.problem.application.exception.ProblemException;
 import cmc.delta.domain.problem.application.mapper.problem.ProblemDetailMapper;
 import cmc.delta.domain.problem.application.mapper.problem.ProblemListMapper;
@@ -21,12 +28,7 @@ import cmc.delta.global.api.response.CursorPagedResponse;
 import cmc.delta.global.api.response.PagedResponse;
 import cmc.delta.global.error.ErrorCode;
 import cmc.delta.global.storage.port.out.StoragePort;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/cmc/delta/domain/problem/application/support/command/SolutionTextNormalizer.java
+++ b/src/main/java/cmc/delta/domain/problem/application/support/command/SolutionTextNormalizer.java
@@ -214,16 +214,7 @@ public final class SolutionTextNormalizer {
 
 	private static String resolveDisplayAnswer(String trailingAnswer, String answerValue, String answerFormat,
 		Integer answerChoiceNo) {
-		if (trailingAnswer != null) {
-			return trailingAnswer;
-		}
-		if (answerChoiceNo != null) {
-			return String.valueOf(answerChoiceNo);
-		}
-		if (answerValue != null && !answerValue.isBlank()) {
-			return answerValue;
-		}
-		return null;
+		return trailingAnswer;
 	}
 
 	private static TrailingAnswerStripResult stripTrailingAnswerLines(String solutionText) {

--- a/src/main/java/cmc/delta/domain/problem/application/support/command/SolutionTextNormalizer.java
+++ b/src/main/java/cmc/delta/domain/problem/application/support/command/SolutionTextNormalizer.java
@@ -25,15 +25,14 @@ public final class SolutionTextNormalizer {
 	 * AI 풀이 텍스트를 저장 전 정규화하는 파이프라인.
 	 * 중복 라인/문장 제거 → 추론 루프 꼬리 제거 → 반복 문장 제거 → 앞부분 중복 블록 제거 → 정답 라인 정규화.
 	 */
-	public static String normalize(String solutionText, String answerValue, String answerFormat,
-		Integer answerChoiceNo) {
+	public static String normalize(String solutionText) {
 		String text = normalizeWhitespace(solutionText);
 		text = deduplicateConsecutiveLines(text);
 		text = deduplicateGlobalLongLines(text);
 		text = truncateReasoningLoopTail(text);
 		text = sanitizeRepeatedSentences(text);
 		text = collapseDuplicatedLeadingBlock(text);
-		return ensureFinalAnswerLine(text, answerValue, answerFormat, answerChoiceNo);
+		return ensureFinalAnswerLine(text);
 	}
 
 	public static String normalizeWhitespace(String solutionText) {
@@ -195,13 +194,11 @@ public final class SolutionTextNormalizer {
 		return firstBlock;
 	}
 
-	private static String ensureFinalAnswerLine(String solutionText, String answerValue, String answerFormat,
-		Integer answerChoiceNo) {
+	private static String ensureFinalAnswerLine(String solutionText) {
 		String normalized = normalizeWhitespace(solutionText);
 		TrailingAnswerStripResult stripResult = stripTrailingAnswerLines(normalized);
 
-		String finalAnswer = resolveDisplayAnswer(stripResult.trailingAnswer(), answerValue, answerFormat,
-			answerChoiceNo);
+		String finalAnswer = stripResult.trailingAnswer();
 
 		if (finalAnswer == null) {
 			return stripResult.body();
@@ -210,11 +207,6 @@ public final class SolutionTextNormalizer {
 			return ANSWER_LINE_PREFIX + " " + finalAnswer;
 		}
 		return stripResult.body() + "\n\n" + ANSWER_LINE_PREFIX + " " + finalAnswer;
-	}
-
-	private static String resolveDisplayAnswer(String trailingAnswer, String answerValue, String answerFormat,
-		Integer answerChoiceNo) {
-		return trailingAnswer;
 	}
 
 	private static TrailingAnswerStripResult stripTrailingAnswerLines(String solutionText) {

--- a/src/main/java/cmc/delta/domain/problem/model/scan/ProblemScan.java
+++ b/src/main/java/cmc/delta/domain/problem/model/scan/ProblemScan.java
@@ -165,10 +165,6 @@ public class ProblemScan extends BaseTimeEntity {
 		return s;
 	}
 
-	public static ProblemScan createUploaded(User user) {
-		return uploaded(user);
-	}
-
 	public static ProblemScan uploadedInGroup(User user, ProblemScanGroup group) {
 		ProblemScan s = uploaded(user);
 		s.scanGroup = group;

--- a/src/main/java/cmc/delta/domain/user/application/port/out/UserRepositoryPort.java
+++ b/src/main/java/cmc/delta/domain/user/application/port/out/UserRepositoryPort.java
@@ -1,9 +1,8 @@
 package cmc.delta.domain.user.application.port.out;
 
-import cmc.delta.domain.user.application.exception.UserException;
-import cmc.delta.domain.user.model.User;
 import java.util.Optional;
 
+import cmc.delta.domain.user.application.exception.UserException;
 import cmc.delta.domain.user.model.User;
 
 public interface UserRepositoryPort {
@@ -15,6 +14,8 @@ public interface UserRepositoryPort {
 
 	void delete(User user);
 
+	long count();
+
 	default User findActiveById(Long id) {
 		User user = findById(id).orElseThrow(UserException::userNotFound);
 		if (user.isWithdrawn()) {
@@ -22,5 +23,4 @@ public interface UserRepositoryPort {
 		}
 		return user;
 	}
-	long count();
 }

--- a/src/main/java/cmc/delta/global/config/security/SecurityConfig.java
+++ b/src/main/java/cmc/delta/global/config/security/SecurityConfig.java
@@ -43,6 +43,11 @@ public class SecurityConfig {
 		"/api/v1/auth/**"
 	};
 
+	public static final String[] JWT_SKIP_PATHS = {
+		"/api/v1/auth/",
+		"/apple/callback"
+	};
+
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 	private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
 	private final RestAccessDeniedHandler restAccessDeniedHandler;

--- a/src/main/java/cmc/delta/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/cmc/delta/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package cmc.delta.global.config.security.jwt;
 
 import cmc.delta.domain.auth.application.port.out.AccessBlacklistStore;
+import cmc.delta.global.config.security.SecurityConfig;
 import cmc.delta.global.config.security.principal.UserPrincipal;
 import cmc.delta.global.error.ErrorCode;
 import jakarta.servlet.FilterChain;
@@ -35,11 +36,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request) {
 		String uri = request.getRequestURI();
-		return uri.startsWith("/api/v1/auth/reissue")
-			|| uri.startsWith("/api/v1/auth/kakao")
-			|| uri.startsWith("/api/v1/auth/apple")
-			|| uri.startsWith("/api/v1/auth/google")
-			|| uri.startsWith("/apple/callback");
+		for (String path : SecurityConfig.JWT_SKIP_PATHS) {
+			if (uri.startsWith(path)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public JwtAuthenticationFilter(

--- a/src/main/java/cmc/delta/global/config/security/jwt/JwtTokenIssuer.java
+++ b/src/main/java/cmc/delta/global/config/security/jwt/JwtTokenIssuer.java
@@ -30,19 +30,9 @@ public class JwtTokenIssuer implements TokenIssuer {
 	}
 
 	@Override
-	public String extractJtiFromAccessToken(String accessToken) {
+	public AccessTokenInfo parseAccessTokenInfo(String accessToken) {
 		JwtTokenProvider.ParsedAccessToken parsed = jwtTokenProvider.parseAccessTokenOrThrow(accessToken);
-		return parsed.jti();
-	}
-
-	@Override
-	public Duration remainingAccessTtl(String accessToken) {
-		JwtTokenProvider.ParsedAccessToken parsed = jwtTokenProvider.parseAccessTokenOrThrow(accessToken);
-
 		Duration ttl = Duration.between(Instant.now(), parsed.expiresAt());
-		if (ttl.isNegative() || ttl.isZero()) {
-			return Duration.ZERO;
-		}
-		return ttl;
+		return new AccessTokenInfo(parsed.jti(), ttl.isNegative() ? Duration.ZERO : ttl);
 	}
 }

--- a/src/main/java/cmc/delta/global/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/cmc/delta/global/config/security/jwt/JwtTokenProvider.java
@@ -46,55 +46,44 @@ public class JwtTokenProvider {
 		if (token == null || token.isBlank()) {
 			throw new JwtAuthenticationException(ErrorCode.TOKEN_REQUIRED);
 		}
-
-		try {
-			Claims claims = parseClaims(token);
-			validateTokenType(claims, TYP_ACCESS, ErrorCode.INVALID_TOKEN);
-
-			Long userId = parseUserId(claims.getSubject(), ErrorCode.INVALID_TOKEN);
-			String role = claims.get(CLAIM_ROLE, String.class);
-			String jti = claims.getId();
-			Instant expiresAt = toInstant(claims.getExpiration(), ErrorCode.INVALID_TOKEN);
-
-			validateRequiredFields(role, jti, expiresAt, ErrorCode.INVALID_TOKEN);
-
-			return new ParsedAccessToken(new UserPrincipal(userId, role), jti, expiresAt);
-
-		} catch (ExpiredJwtException e) {
-			throw new JwtAuthenticationException(ErrorCode.EXPIRED_TOKEN);
-		} catch (JwtAuthenticationException e) {
-			throw e;
-		} catch (JwtException | IllegalArgumentException e) {
-			throw new JwtAuthenticationException(ErrorCode.INVALID_TOKEN);
-		}
+		return parseAndBuild(token, TYP_ACCESS, ErrorCode.INVALID_TOKEN, ErrorCode.EXPIRED_TOKEN,
+			ParsedAccessToken::new);
 	}
 
 	public ParsedRefreshToken parseRefreshTokenOrThrow(String token) {
 		if (token == null || token.isBlank()) {
 			throw new JwtAuthenticationException(ErrorCode.REFRESH_TOKEN_REQUIRED);
 		}
+		return parseAndBuild(token, TYP_REFRESH, ErrorCode.INVALID_REFRESH_TOKEN, ErrorCode.INVALID_REFRESH_TOKEN,
+			ParsedRefreshToken::new);
+	}
 
+	private <T> T parseAndBuild(String token, String expectedTyp, ErrorCode invalidCode, ErrorCode expiredCode,
+		TokenFactory<T> factory) {
 		try {
-			Claims claims = parseClaims(token);
-			validateTokenType(claims, TYP_REFRESH, ErrorCode.INVALID_REFRESH_TOKEN);
+			Claims claims = parseVerifiedClaims(token);
+			validateTokenType(claims, expectedTyp, invalidCode);
 
-			Long userId = parseUserId(claims.getSubject(), ErrorCode.INVALID_REFRESH_TOKEN);
+			Long userId = parseUserId(claims.getSubject(), invalidCode);
 			String role = claims.get(CLAIM_ROLE, String.class);
 			String jti = claims.getId();
-			Instant expiresAt = toInstant(claims.getExpiration(), ErrorCode.INVALID_REFRESH_TOKEN);
+			Instant expiresAt = toInstant(claims.getExpiration(), invalidCode);
 
-			validateRequiredFields(role, jti, expiresAt, ErrorCode.INVALID_REFRESH_TOKEN);
-
-			return new ParsedRefreshToken(new UserPrincipal(userId, role), jti, expiresAt);
+			validateRequiredFields(role, jti, expiresAt, invalidCode);
+			return factory.create(new UserPrincipal(userId, role), jti, expiresAt);
 
 		} catch (ExpiredJwtException e) {
-			// refresh 만료 전용 코드가 없으니 정책상 INVALID_REFRESH_TOKEN로 처리
-			throw new JwtAuthenticationException(ErrorCode.INVALID_REFRESH_TOKEN);
+			throw new JwtAuthenticationException(expiredCode);
 		} catch (JwtAuthenticationException e) {
 			throw e;
 		} catch (JwtException | IllegalArgumentException e) {
-			throw new JwtAuthenticationException(ErrorCode.INVALID_REFRESH_TOKEN);
+			throw new JwtAuthenticationException(invalidCode);
 		}
+	}
+
+	@FunctionalInterface
+	private interface TokenFactory<T> {
+		T create(UserPrincipal principal, String jti, Instant expiresAt);
 	}
 
 	private String issueToken(UserPrincipal principal, String typ, long ttlSeconds) {
@@ -114,7 +103,7 @@ public class JwtTokenProvider {
 			.compact();
 	}
 
-	private Claims parseClaims(String token) {
+	private Claims parseVerifiedClaims(String token) {
 		Jws<Claims> jws = Jwts.parser().verifyWith(signingKey).build().parseSignedClaims(token);
 		return jws.getPayload();
 	}

--- a/src/main/java/cmc/delta/global/storage/S3PresignerWarmup.java
+++ b/src/main/java/cmc/delta/global/storage/S3PresignerWarmup.java
@@ -1,0 +1,30 @@
+package cmc.delta.global.storage;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import cmc.delta.global.storage.application.StorageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3PresignerWarmup implements ApplicationRunner {
+
+	private final StorageService storageService;
+
+	@Override
+	public void run(ApplicationArguments args) {
+		long start = System.nanoTime();
+		try {
+			storageService.issueReadUrl("warmup/dummy", null);
+		} catch (Exception e) {
+			// 더미 키라 S3에 없어도 presign 서명 자체는 로컬에서 완료됨
+		} finally {
+			long ms = (System.nanoTime() - start) / 1_000_000;
+			log.info("[WARMUP] S3Presigner 초기화 완료 ({}ms)", ms);
+		}
+	}
+}

--- a/src/test/java/cmc/delta/domain/auth/application/service/provisioning/UserProvisioningServiceImplTest.java
+++ b/src/test/java/cmc/delta/domain/auth/application/service/provisioning/UserProvisioningServiceImplTest.java
@@ -11,10 +11,12 @@ import cmc.delta.domain.auth.model.SocialProvider;
 import cmc.delta.domain.user.application.exception.UserException;
 import cmc.delta.domain.user.application.support.FakeUserRepositoryPort;
 import cmc.delta.domain.user.model.User;
+import cmc.delta.global.config.WebhookConfig;
 import cmc.delta.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
 
 class UserProvisioningServiceImplTest {
 
@@ -27,7 +29,7 @@ class UserProvisioningServiceImplTest {
 		userRepositoryPort = FakeUserRepositoryPort.create();
 		socialAccountRepositoryPort = FakeSocialAccountRepositoryPort.create();
 		sut = new UserProvisioningServiceImpl(userRepositoryPort, socialAccountRepositoryPort,
-			new SocialUserProvisionValidator());
+			new SocialUserProvisionValidator(), mock(WebhookConfig.class));
 	}
 
 	@Test

--- a/src/test/java/cmc/delta/domain/auth/application/support/FakeTokenIssuer.java
+++ b/src/test/java/cmc/delta/domain/auth/application/support/FakeTokenIssuer.java
@@ -37,19 +37,16 @@ public class FakeTokenIssuer implements TokenIssuer {
 	}
 
 	@Override
-	public String extractJtiFromAccessToken(String accessToken) {
+	public AccessTokenInfo parseAccessTokenInfo(String accessToken) {
 		String[] parts = accessToken.split(":");
-		return parts[2];
+		String jti = parts[2];
+		long expEpochSecond = Long.parseLong(parts[3]);
+		long remain = expEpochSecond - clock.instant().getEpochSecond();
+		Duration ttl = Duration.ofSeconds(Math.max(remain, 0));
+		return new AccessTokenInfo(jti, ttl);
 	}
 
-	@Override
-	public Duration remainingAccessTtl(String accessToken) {
-		String[] parts = accessToken.split(":");
-		long expEpochSecond = Long.parseLong(parts[3]);
-
-		long nowEpochSecond = clock.instant().getEpochSecond();
-		long remain = expEpochSecond - nowEpochSecond;
-
-		return Duration.ofSeconds(Math.max(remain, 0));
+	public String extractJtiFromAccessToken(String accessToken) {
+		return parseAccessTokenInfo(accessToken).jti();
 	}
 }

--- a/src/test/java/cmc/delta/domain/auth/application/support/InMemoryRefreshTokenStore.java
+++ b/src/test/java/cmc/delta/domain/auth/application/support/InMemoryRefreshTokenStore.java
@@ -56,6 +56,16 @@ public class InMemoryRefreshTokenStore implements RefreshTokenStore {
 	}
 
 	@Override
+	public boolean refreshExists(Long userId, String sessionId, String expectedHash) {
+		if (userId == null || isBlank(expectedHash))
+			return false;
+		Entry entry = store.get(key(userId, sessionId));
+		if (entry == null || entry.isExpired(clock.instant()))
+			return false;
+		return entry.hash.equals(expectedHash);
+	}
+
+	@Override
 	public void refreshDelete(Long userId, String sessionId) {
 		if (userId == null)
 			return;

--- a/src/test/java/cmc/delta/domain/auth/application/token/TokenServiceImplLogoutTest.java
+++ b/src/test/java/cmc/delta/domain/auth/application/token/TokenServiceImplLogoutTest.java
@@ -1,0 +1,102 @@
+package cmc.delta.domain.auth.application.token;
+
+import static org.assertj.core.api.Assertions.*;
+
+import cmc.delta.domain.auth.application.exception.TokenException;
+import cmc.delta.domain.auth.application.port.out.TokenIssuer;
+import cmc.delta.domain.auth.application.service.token.TokenServiceImpl;
+import cmc.delta.domain.auth.application.support.FakeTokenIssuer;
+import cmc.delta.domain.auth.application.support.InMemoryAccessBlacklistStore;
+import cmc.delta.domain.auth.application.support.InMemoryRefreshTokenStore;
+import cmc.delta.domain.auth.application.support.RefreshTokenHasher;
+import cmc.delta.domain.auth.application.support.TokenFixtures;
+import cmc.delta.global.config.security.principal.UserPrincipal;
+import cmc.delta.global.error.ErrorCode;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TokenServiceImplLogoutTest {
+
+	private InMemoryRefreshTokenStore refreshTokenStore;
+	private InMemoryAccessBlacklistStore blacklistStore;
+	private FakeTokenIssuer tokenIssuer;
+	private TokenServiceImpl tokenService;
+
+	@BeforeEach
+	void setUp() {
+		refreshTokenStore = new InMemoryRefreshTokenStore(TokenFixtures.fixedClock());
+		blacklistStore = new InMemoryAccessBlacklistStore();
+		tokenIssuer = new FakeTokenIssuer(TokenFixtures.fixedClock(), Duration.ofMinutes(15));
+
+		tokenService = new TokenServiceImpl(
+			tokenIssuer,
+			refreshTokenStore,
+			blacklistStore,
+			TokenFixtures.noopAuditLogger());
+	}
+
+	@Test
+	@DisplayName("로그아웃하면 리프레시 해시가 삭제됨")
+	void logout_whenCalled_thenRefreshIsDeleted() {
+		// given
+		UserPrincipal principal = TokenFixtures.principal(1L);
+		TokenIssuer.IssuedTokens tokens = tokenService.issue(principal);
+
+		// when
+		tokenService.logout(principal.userId(), tokens.accessToken(), tokens.refreshToken());
+
+		// then
+		assertThat(refreshTokenStore.getSavedHashOrNull(principal.userId(), TokenFixtures.DEFAULT_SESSION_ID)).isNull();
+	}
+
+	@Test
+	@DisplayName("로그아웃하면 액세스 jti가 블랙리스트에 등록됨")
+	void logout_whenCalled_thenAccessJtiIsBlacklisted() {
+		// given
+		UserPrincipal principal = TokenFixtures.principal(1L);
+		TokenIssuer.IssuedTokens tokens = tokenService.issue(principal);
+		String jti = tokenIssuer.extractJtiFromAccessToken(tokens.accessToken());
+
+		// when
+		tokenService.logout(principal.userId(), tokens.accessToken(), tokens.refreshToken());
+
+		// then
+		assertThat(blacklistStore.isBlacklisted(jti)).isTrue();
+	}
+
+	@Test
+	@DisplayName("로그아웃 시 리프레시 해시가 불일치하면 INVALID_REFRESH_TOKEN이 발생함")
+	void logout_whenRefreshMismatch_thenThrowsInvalidRefreshToken() {
+		// given
+		UserPrincipal principal = TokenFixtures.principal(1L);
+		TokenIssuer.IssuedTokens tokens = tokenService.issue(principal);
+		String wrongRefresh = tokens.refreshToken() + "_tampered";
+
+		// when
+		TokenException ex = catchThrowableOfType(
+			() -> tokenService.logout(principal.userId(), tokens.accessToken(), wrongRefresh),
+			TokenException.class);
+
+		// then
+		assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+	}
+
+	@Test
+	@DisplayName("로그아웃 후 리프레시 해시 TTL이 갱신되지 않음 — rotate 오용 방지")
+	void logout_doesNotRotateRefreshHash() {
+		// given
+		UserPrincipal principal = TokenFixtures.principal(1L);
+		TokenIssuer.IssuedTokens tokens = tokenService.issue(principal);
+		String hashBefore = refreshTokenStore.getSavedHashOrNull(principal.userId(), TokenFixtures.DEFAULT_SESSION_ID);
+
+		// when
+		tokenService.logout(principal.userId(), tokens.accessToken(), tokens.refreshToken());
+
+		// then: 로그아웃 후 해시 자체는 삭제됨 (rotate 됐다면 새 해시로 바뀌어 있을 것)
+		String hashAfter = refreshTokenStore.getSavedHashOrNull(principal.userId(), TokenFixtures.DEFAULT_SESSION_ID);
+		assertThat(hashBefore).isEqualTo(RefreshTokenHasher.sha256(tokens.refreshToken()));
+		assertThat(hashAfter).isNull();
+	}
+}

--- a/src/test/java/cmc/delta/domain/problem/adapter/in/worker/support/WorkerFixtures.java
+++ b/src/test/java/cmc/delta/domain/problem/adapter/in/worker/support/WorkerFixtures.java
@@ -21,11 +21,11 @@ public final class WorkerFixtures {
 	}
 
 	public static ProblemScan uploaded(User user) {
-		return ProblemScan.createUploaded(user);
+		return ProblemScan.uploaded(user);
 	}
 
 	public static ProblemScan ocrDone(User user, String text) {
-		ProblemScan scan = ProblemScan.createUploaded(user);
+		ProblemScan scan = ProblemScan.uploaded(user);
 		scan.markOcrSucceeded(text, "{}", LocalDateTime.now());
 		return scan;
 	}

--- a/src/test/java/cmc/delta/domain/problem/adapter/out/persistence/scan/prediction/ScanTypePredictionPersistenceAdapterTest.java
+++ b/src/test/java/cmc/delta/domain/problem/adapter/out/persistence/scan/prediction/ScanTypePredictionPersistenceAdapterTest.java
@@ -97,11 +97,9 @@ class ScanTypePredictionPersistenceAdapterTest {
 		// T4는 없는 타입
 		ProblemType t5 = mockType("T5");
 
-		when(typeReader.findById("T1")).thenReturn(Optional.of(t1));
-		when(typeReader.findById("T2")).thenReturn(Optional.of(t2));
-		when(typeReader.findById("T3")).thenReturn(Optional.of(t3));
-		when(typeReader.findById("T4")).thenReturn(Optional.empty());
-		when(typeReader.findById("T5")).thenReturn(Optional.of(t5));
+		// 구현체는 findByIds로 IN절 일괄 조회 — T4는 결과에 포함되지 않음
+		when(typeReader.findByIds(List.of("T1", "T2", "T3", "T4", "T5")))
+			.thenReturn(List.of(t1, t2, t3, t5));
 		// T6는 호출되면 안 됨(상위 5개 제한)
 
 		@SuppressWarnings("unchecked") org.mockito.ArgumentCaptor<List<ProblemScanTypePrediction>> captor = org.mockito.ArgumentCaptor

--- a/src/test/java/cmc/delta/domain/problem/application/support/FakeUserRepositoryPort.java
+++ b/src/test/java/cmc/delta/domain/problem/application/support/FakeUserRepositoryPort.java
@@ -49,4 +49,9 @@ public final class FakeUserRepositoryPort implements UserRepositoryPort {
 			return;
 		store.remove(user.getId());
 	}
+
+	@Override
+	public long count() {
+		return store.size();
+	}
 }

--- a/src/test/java/cmc/delta/domain/user/application/support/FakeUserRepositoryPort.java
+++ b/src/test/java/cmc/delta/domain/user/application/support/FakeUserRepositoryPort.java
@@ -54,6 +54,11 @@ public final class FakeUserRepositoryPort implements UserRepositoryPort {
 		store.remove(user.getId());
 	}
 
+	@Override
+	public long count() {
+		return store.size();
+	}
+
 	public int deleteCallCount() {
 		return deleteCallCount;
 	}

--- a/src/test/java/cmc/delta/global/config/security/jwt/JwtAuthenticationFilterSkipTest.java
+++ b/src/test/java/cmc/delta/global/config/security/jwt/JwtAuthenticationFilterSkipTest.java
@@ -1,0 +1,98 @@
+package cmc.delta.global.config.security.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import cmc.delta.domain.auth.application.port.out.AccessBlacklistStore;
+import cmc.delta.global.config.security.SecurityConfig;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+class JwtAuthenticationFilterSkipTest {
+
+	private JwtAuthenticationFilter filter;
+
+	@BeforeEach
+	void setUp() {
+		JwtProperties properties = new JwtProperties(
+			"delta-test-issuer",
+			"dGVzdC1zZWNyZXQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLUhTMjU2",
+			900L,
+			1209600L,
+			new JwtProperties.Blacklist(false));
+
+		filter = new JwtAuthenticationFilter(
+			mock(BearerTokenResolver.class),
+			mock(JwtTokenProvider.class),
+			mock(AccessBlacklistStore.class),
+			properties,
+			mock(AuthenticationEntryPoint.class));
+	}
+
+	static Stream<String> skipPaths() {
+		return Stream.of(
+			"/api/v1/auth/kakao",
+			"/api/v1/auth/google",
+			"/api/v1/auth/apple",
+			"/api/v1/auth/reissue",
+			"/apple/callback");
+	}
+
+	@ParameterizedTest
+	@MethodSource("skipPaths")
+	@DisplayName("JWT_SKIP_PATHS에 해당하는 경로는 필터를 건너뜀")
+	void shouldNotFilter_whenSkipPath_thenTrue(String path) throws Exception {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRequestURI(path);
+
+		// when
+		boolean skipped = filter.shouldNotFilter(request);
+
+		// then
+		assertThat(skipped).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"/api/v1/problems",
+		"/api/v1/users/me",
+		"/api/v1/auth-other/something"
+	})
+	@DisplayName("JWT_SKIP_PATHS에 해당하지 않는 경로는 필터를 통과함")
+	void shouldNotFilter_whenNonSkipPath_thenFalse(String path) throws Exception {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRequestURI(path);
+
+		// when
+		boolean skipped = filter.shouldNotFilter(request);
+
+		// then
+		assertThat(skipped).isFalse();
+	}
+
+	@ParameterizedTest
+	@MethodSource("skipPaths")
+	@DisplayName("JWT_SKIP_PATHS 상수와 shouldNotFilter 결과가 일치함")
+	void shouldNotFilter_matchesJwtSkipPathsConstant(String path) throws Exception {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRequestURI(path);
+
+		boolean expectedSkip = Stream.of(SecurityConfig.JWT_SKIP_PATHS)
+			.anyMatch(path::startsWith);
+
+		// when
+		boolean actualSkip = filter.shouldNotFilter(request);
+
+		// then
+		assertThat(actualSkip).isEqualTo(expectedSkip);
+	}
+}

--- a/src/test/java/cmc/delta/global/config/security/jwt/JwtTokenIssuerTest.java
+++ b/src/test/java/cmc/delta/global/config/security/jwt/JwtTokenIssuerTest.java
@@ -1,0 +1,74 @@
+package cmc.delta.global.config.security.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+
+import cmc.delta.domain.auth.application.port.out.TokenIssuer;
+import cmc.delta.global.config.security.principal.UserPrincipal;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JwtTokenIssuerTest {
+
+	private JwtTokenIssuer tokenIssuer;
+
+	@BeforeEach
+	void setUp() {
+		JwtProperties properties = new JwtProperties(
+			"delta-test-issuer",
+			"dGVzdC1zZWNyZXQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLUhTMjU2",
+			Duration.ofMinutes(15).toSeconds(),
+			Duration.ofDays(14).toSeconds(),
+			new JwtProperties.Blacklist(true));
+
+		JwtTokenProvider provider = new JwtTokenProvider(properties);
+		tokenIssuer = new JwtTokenIssuer(provider);
+	}
+
+	@Test
+	@DisplayName("parseAccessTokenInfo는 jti와 remainingTtl을 한 번에 반환함")
+	void parseAccessTokenInfo_returnsBothJtiAndTtl() {
+		// given
+		UserPrincipal principal = new UserPrincipal(1L, "USER");
+		TokenIssuer.IssuedTokens tokens = tokenIssuer.issue(principal);
+
+		// when
+		TokenIssuer.AccessTokenInfo info = tokenIssuer.parseAccessTokenInfo(tokens.accessToken());
+
+		// then
+		assertThat(info.jti()).isNotBlank();
+		assertThat(info.remainingTtl()).isPositive();
+		assertThat(info.remainingTtl()).isLessThanOrEqualTo(Duration.ofMinutes(15));
+	}
+
+	@Test
+	@DisplayName("parseAccessTokenInfo의 remainingTtl은 만료 전이면 양수임")
+	void parseAccessTokenInfo_whenNotExpired_thenTtlIsPositive() {
+		// given
+		UserPrincipal principal = new UserPrincipal(2L, "USER");
+		TokenIssuer.IssuedTokens tokens = tokenIssuer.issue(principal);
+
+		// when
+		TokenIssuer.AccessTokenInfo info = tokenIssuer.parseAccessTokenInfo(tokens.accessToken());
+
+		// then
+		assertThat(info.remainingTtl().isZero()).isFalse();
+		assertThat(info.remainingTtl().isNegative()).isFalse();
+	}
+
+	@Test
+	@DisplayName("같은 토큰으로 두 번 parseAccessTokenInfo를 호출하면 동일한 jti를 반환함")
+	void parseAccessTokenInfo_calledTwice_returnsSameJti() {
+		// given
+		UserPrincipal principal = new UserPrincipal(3L, "USER");
+		TokenIssuer.IssuedTokens tokens = tokenIssuer.issue(principal);
+
+		// when
+		TokenIssuer.AccessTokenInfo first = tokenIssuer.parseAccessTokenInfo(tokens.accessToken());
+		TokenIssuer.AccessTokenInfo second = tokenIssuer.parseAccessTokenInfo(tokens.accessToken());
+
+		// then
+		assertThat(first.jti()).isEqualTo(second.jti());
+	}
+}


### PR DESCRIPTION
# refactor: AI가 분류 이후 IN절로 불러오도록 코드 변경

## Ⅰ. PR 내용 설명 (Describe what this PR did)

- AI 분류 결과를 기반으로 데이터를 조회할 때 기존 방식에서 **IN절(IN clause)** 을 활용하는 방식으로 쿼리 로직을 리팩토링하였습니다.
- 오답 리스트 첫 요청 시 발생할 수 있는 지연을 줄이기 위해 **워밍업(Warming-up) 로직**을 추가하였습니다.
- AI 문제 풀이 화면에서 마지막에 사용자가 선택한 정답이 노출되는 버그를 수정하였습니다.

## Ⅱ. 관련 이슈 (Does this pull request fix one issue?)

## Ⅲ. 검증 방법 (Describe how to verify it)

1. AI 분류 기능을 실행한 뒤, 분류된 항목들이 IN절을 통해 정상적으로 조회되는지 확인합니다.
2. 오답 리스트 화면을 **최초 진입** 시 워밍업 로직이 동작하고, 이후 응답 속도가 개선되었는지 확인합니다.
3. AI 문제 풀이를 완료한 후 마지막 화면에서 사용자가 선택한 정답이 **노출되지 않는지** 확인합니다.

## Ⅳ. 리뷰 시 참고 사항 (Special notes for reviews)

- IN절 변경으로 인해 쿼리 파라미터 바인딩 방식이 달라졌으므로, **쿼리 성능 및 파라미터 개수 제한** 에 유의해주세요.
- 워밍업 로직은 첫 요청 시에만 트리거되도록 설계되었습니다. 중복 호출이 발생하지 않는지 확인 부탁드립니다.
- 정답 노출 버그 수정은 렌더링 조건 로직을 변경한 것으로, 관련 UI 흐름 전반을 함께 검토해 주시면 좋겠습니다.