### PR TITLE
feat: 관리자 대시보드 문제 등록 조회 API추가 및 월별 접속자 조회 리팩토링

### DIFF
--- a/src/main/java/cmc/delta/domain/dashboard/adapter/in/web/DashboardController.java
+++ b/src/main/java/cmc/delta/domain/dashboard/adapter/in/web/DashboardController.java
@@ -1,8 +1,10 @@
 package cmc.delta.domain.dashboard.adapter.in.web;
 
 import cmc.delta.domain.dashboard.adapter.in.web.dto.request.DashboardMonthlyAccessRequest;
+import cmc.delta.domain.dashboard.adapter.in.web.dto.request.DashboardProblemsRequest;
 import cmc.delta.domain.dashboard.adapter.in.web.dto.request.DashboardUsersRequest;
 import cmc.delta.domain.dashboard.application.dto.DashboardMonthlyAccessResponse;
+import cmc.delta.domain.dashboard.application.dto.DashboardProblemsResponse;
 import cmc.delta.domain.dashboard.application.dto.DashboardUsersResponse;
 import cmc.delta.domain.dashboard.application.port.in.DashboardQueryUseCase;
 import cmc.delta.global.api.response.ApiResponse;
@@ -39,5 +41,12 @@ public class DashboardController {
 		@ModelAttribute DashboardMonthlyAccessRequest request) {
 		return ApiResponses.success(SuccessCode.OK,
 			dashboardQueryUseCase.getMonthlyAccess(request.toYearMonth()));
+	}
+
+	@Operation(summary = "문제 등록 현황 조회", description = DashboardApiDocs.GET_PROBLEMS)
+	@GetMapping("/problems")
+	public ApiResponse<DashboardProblemsResponse> getProblems(@ModelAttribute DashboardProblemsRequest request) {
+		return ApiResponses.success(SuccessCode.OK,
+			dashboardQueryUseCase.getProblems(PageRequest.of(request.page(), request.size())));
 	}
 }

--- a/src/main/java/cmc/delta/domain/dashboard/adapter/in/web/dto/request/DashboardProblemsRequest.java
+++ b/src/main/java/cmc/delta/domain/dashboard/adapter/in/web/dto/request/DashboardProblemsRequest.java
@@ -1,0 +1,17 @@
+package cmc.delta.domain.dashboard.adapter.in.web.dto.request;
+
+public record DashboardProblemsRequest(Integer page, Integer size) {
+
+	private static final int DEFAULT_PAGE = 0;
+	private static final int DEFAULT_SIZE = 20;
+	private static final int MAX_SIZE = 100;
+
+	public DashboardProblemsRequest {
+		if (page == null || page < 0)
+			page = DEFAULT_PAGE;
+		if (size == null || size <= 0)
+			size = DEFAULT_SIZE;
+		if (size > MAX_SIZE)
+			size = MAX_SIZE;
+	}
+}

--- a/src/main/java/cmc/delta/domain/dashboard/adapter/out/persistence/DashboardMonthlyAccessQueryRepositoryImpl.java
+++ b/src/main/java/cmc/delta/domain/dashboard/adapter/out/persistence/DashboardMonthlyAccessQueryRepositoryImpl.java
@@ -25,13 +25,18 @@ public class DashboardMonthlyAccessQueryRepositoryImpl implements DashboardMonth
 	@Override
 	public Map<LocalDate, Long> findDailyAccessByMonth(YearMonth yearMonth) {
 		QUserDailyAccess access = QUserDailyAccess.userDailyAccess;
+		QUser user = QUser.user;
 		LocalDate start = yearMonth.atDay(1);
 		LocalDate end = yearMonth.atEndOfMonth();
 
 		return queryFactory
 			.select(access.accessDate, access.userId.countDistinct())
 			.from(access)
-			.where(access.accessDate.between(start, end))
+			.join(user).on(user.id.eq(access.userId))
+			.where(
+				access.accessDate.between(start, end),
+				user.role.ne(UserRole.ADMIN)
+			)
 			.groupBy(access.accessDate)
 			.fetch()
 			.stream()

--- a/src/main/java/cmc/delta/domain/dashboard/adapter/out/persistence/DashboardMonthlyAccessQueryRepositoryImpl.java
+++ b/src/main/java/cmc/delta/domain/dashboard/adapter/out/persistence/DashboardMonthlyAccessQueryRepositoryImpl.java
@@ -1,14 +1,18 @@
 package cmc.delta.domain.dashboard.adapter.out.persistence;
 
-import static com.querydsl.core.types.Projections.constructor;
-
-import cmc.delta.domain.dashboard.application.dto.DashboardDailyAccessItem;
 import cmc.delta.domain.dashboard.application.port.out.DashboardMonthlyAccessQueryPort;
 import cmc.delta.domain.stats.model.QUserDailyAccess;
+import cmc.delta.domain.user.model.QUser;
+import cmc.delta.domain.user.model.enums.UserRole;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.DateTemplate;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -19,19 +23,47 @@ public class DashboardMonthlyAccessQueryRepositoryImpl implements DashboardMonth
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public List<DashboardDailyAccessItem> findDailyAccessByMonth(YearMonth yearMonth) {
+	public Map<LocalDate, Long> findDailyAccessByMonth(YearMonth yearMonth) {
 		QUserDailyAccess access = QUserDailyAccess.userDailyAccess;
 		LocalDate start = yearMonth.atDay(1);
 		LocalDate end = yearMonth.atEndOfMonth();
 
 		return queryFactory
-			.select(constructor(DashboardDailyAccessItem.class,
-				access.accessDate,
-				access.userId.countDistinct()))
+			.select(access.accessDate, access.userId.countDistinct())
 			.from(access)
 			.where(access.accessDate.between(start, end))
 			.groupBy(access.accessDate)
-			.orderBy(access.accessDate.asc())
+			.fetch()
+			.stream()
+			.collect(Collectors.toMap(
+				t -> t.get(access.accessDate),
+				t -> t.get(access.userId.countDistinct())
+			));
+	}
+
+	@Override
+	public Map<LocalDate, Long> findDailyNewUsersByMonth(YearMonth yearMonth) {
+		QUser user = QUser.user;
+		LocalDate start = yearMonth.atDay(1);
+
+		DateTemplate<LocalDate> signupDate = Expressions.dateTemplate(
+			LocalDate.class, "DATE({0})", user.createdAt);
+
+		List<Tuple> results = queryFactory
+			.select(signupDate, user.id.count())
+			.from(user)
+			.where(
+				user.createdAt.goe(start.atStartOfDay()),
+				user.createdAt.lt(yearMonth.plusMonths(1).atDay(1).atStartOfDay()),
+				user.role.ne(UserRole.ADMIN)
+			)
+			.groupBy(signupDate)
 			.fetch();
+
+		return results.stream()
+			.collect(Collectors.toMap(
+				t -> t.get(signupDate),
+				t -> t.get(user.id.count())
+			));
 	}
 }

--- a/src/main/java/cmc/delta/domain/dashboard/adapter/out/persistence/DashboardMonthlyAccessQueryRepositoryImpl.java
+++ b/src/main/java/cmc/delta/domain/dashboard/adapter/out/persistence/DashboardMonthlyAccessQueryRepositoryImpl.java
@@ -29,13 +29,19 @@ public class DashboardMonthlyAccessQueryRepositoryImpl implements DashboardMonth
 		LocalDate start = yearMonth.atDay(1);
 		LocalDate end = yearMonth.atEndOfMonth();
 
+		// 1. ADMIN ID 목록 선조회
+		List<Long> adminIds = queryFactory
+			.select(user.id)
+			.from(user)
+			.where(user.role.eq(UserRole.ADMIN))
+			.fetch();
+
 		return queryFactory
 			.select(access.accessDate, access.userId.countDistinct())
 			.from(access)
-			.join(user).on(user.id.eq(access.userId))
 			.where(
 				access.accessDate.between(start, end),
-				user.role.ne(UserRole.ADMIN)
+				adminIds.isEmpty() ? null : access.userId.notIn(adminIds)
 			)
 			.groupBy(access.accessDate)
 			.fetch()

--- a/src/main/java/cmc/delta/domain/dashboard/adapter/out/persistence/DashboardProblemQueryRepositoryImpl.java
+++ b/src/main/java/cmc/delta/domain/dashboard/adapter/out/persistence/DashboardProblemQueryRepositoryImpl.java
@@ -7,9 +7,7 @@ import cmc.delta.domain.curriculum.model.QUnit;
 import cmc.delta.domain.dashboard.application.dto.DashboardProblemItem;
 import cmc.delta.domain.dashboard.application.port.out.DashboardProblemQueryPort;
 import cmc.delta.domain.problem.model.problem.QProblem;
-import cmc.delta.domain.problem.model.problem.QProblemAiSolutionTask;
 import cmc.delta.domain.user.model.QUser;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +27,6 @@ public class DashboardProblemQueryRepositoryImpl implements DashboardProblemQuer
 		QUnit parentUnit = new QUnit("parentUnit");
 		QProblemType type = QProblemType.problemType;
 		QUser user = QUser.user;
-		QProblemAiSolutionTask task = QProblemAiSolutionTask.problemAiSolutionTask;
 
 		return queryFactory
 			.select(constructor(DashboardProblemItem.class,
@@ -37,9 +34,8 @@ public class DashboardProblemQueryRepositoryImpl implements DashboardProblemQuer
 				unit.name,
 				parentUnit.name,
 				type.name,
-				new CaseBuilder()
-					.when(task.id.isNotNull()).then(1L)
-					.otherwise(0L),
+				problem.aiSolutionCount.longValue(),
+				problem.viewCount.longValue(),
 				problem.createdAt,
 				problem.completedAt.isNotNull(),
 				user.role))
@@ -48,7 +44,6 @@ public class DashboardProblemQueryRepositoryImpl implements DashboardProblemQuer
 			.leftJoin(unit.parent, parentUnit)
 			.leftJoin(problem.finalType, type)
 			.leftJoin(problem.user, user)
-			.leftJoin(task).on(task.problem.id.eq(problem.id))
 			.orderBy(problem.id.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())

--- a/src/main/java/cmc/delta/domain/dashboard/adapter/out/persistence/DashboardProblemQueryRepositoryImpl.java
+++ b/src/main/java/cmc/delta/domain/dashboard/adapter/out/persistence/DashboardProblemQueryRepositoryImpl.java
@@ -1,0 +1,69 @@
+package cmc.delta.domain.dashboard.adapter.out.persistence;
+
+import static com.querydsl.core.types.Projections.constructor;
+
+import cmc.delta.domain.curriculum.model.QProblemType;
+import cmc.delta.domain.curriculum.model.QUnit;
+import cmc.delta.domain.dashboard.application.dto.DashboardProblemItem;
+import cmc.delta.domain.dashboard.application.port.out.DashboardProblemQueryPort;
+import cmc.delta.domain.problem.model.problem.QProblem;
+import cmc.delta.domain.problem.model.problem.QProblemAiSolutionTask;
+import cmc.delta.domain.user.model.QUser;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DashboardProblemQueryRepositoryImpl implements DashboardProblemQueryPort {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<DashboardProblemItem> findProblems(Pageable pageable) {
+		QProblem problem = QProblem.problem;
+		QUnit unit = QUnit.unit;
+		QUnit parentUnit = new QUnit("parentUnit");
+		QProblemType type = QProblemType.problemType;
+		QUser user = QUser.user;
+		QProblemAiSolutionTask task = QProblemAiSolutionTask.problemAiSolutionTask;
+
+		return queryFactory
+			.select(constructor(DashboardProblemItem.class,
+				problem.id,
+				unit.name,
+				parentUnit.name,
+				type.name,
+				new CaseBuilder()
+					.when(task.id.isNotNull()).then(1L)
+					.otherwise(0L),
+				problem.createdAt,
+				problem.completedAt.isNotNull(),
+				user.role))
+			.from(problem)
+			.leftJoin(problem.finalUnit, unit)
+			.leftJoin(unit.parent, parentUnit)
+			.leftJoin(problem.finalType, type)
+			.leftJoin(problem.user, user)
+			.leftJoin(task).on(task.problem.id.eq(problem.id))
+			.orderBy(problem.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+	}
+
+	@Override
+	public long countProblems() {
+		QProblem problem = QProblem.problem;
+
+		Long count = queryFactory
+			.select(problem.id.count())
+			.from(problem)
+			.fetchOne();
+
+		return count != null ? count : 0L;
+	}
+}

--- a/src/main/java/cmc/delta/domain/dashboard/adapter/out/persistence/DashboardProblemQueryRepositoryImpl.java
+++ b/src/main/java/cmc/delta/domain/dashboard/adapter/out/persistence/DashboardProblemQueryRepositoryImpl.java
@@ -8,6 +8,8 @@ import cmc.delta.domain.dashboard.application.dto.DashboardProblemItem;
 import cmc.delta.domain.dashboard.application.port.out.DashboardProblemQueryPort;
 import cmc.delta.domain.problem.model.problem.QProblem;
 import cmc.delta.domain.user.model.QUser;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +46,7 @@ public class DashboardProblemQueryRepositoryImpl implements DashboardProblemQuer
 			.leftJoin(unit.parent, parentUnit)
 			.leftJoin(problem.finalType, type)
 			.leftJoin(problem.user, user)
+			.where(getCommonWhereConditions())
 			.orderBy(problem.id.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
@@ -57,8 +60,17 @@ public class DashboardProblemQueryRepositoryImpl implements DashboardProblemQuer
 		Long count = queryFactory
 			.select(problem.id.count())
 			.from(problem)
+			.where(getCommonWhereConditions())
 			.fetchOne();
 
 		return count != null ? count : 0L;
+	}
+
+	private BooleanExpression[] getCommonWhereConditions() {
+		QProblem problem = QProblem.problem;
+
+		return new BooleanExpression[] {
+			// 지금은 조건이 없으므로 빈 배열을 반환하거나 null을 반환하도록 설계합니다.
+		};
 	}
 }

--- a/src/main/java/cmc/delta/domain/dashboard/application/dto/DashboardDailyAccessItem.java
+++ b/src/main/java/cmc/delta/domain/dashboard/application/dto/DashboardDailyAccessItem.java
@@ -2,5 +2,5 @@ package cmc.delta.domain.dashboard.application.dto;
 
 import java.time.LocalDate;
 
-public record DashboardDailyAccessItem(LocalDate date, long count) {
+public record DashboardDailyAccessItem(LocalDate date, long dailyVisitors, long newUsers) {
 }

--- a/src/main/java/cmc/delta/domain/dashboard/application/dto/DashboardProblemItem.java
+++ b/src/main/java/cmc/delta/domain/dashboard/application/dto/DashboardProblemItem.java
@@ -9,6 +9,7 @@ public record DashboardProblemItem(
 	String unitName,
 	String problemType,
 	long aiSolutionCount,
+	long viewCount,
 	LocalDateTime registeredAt,
 	boolean wrongAnswerCompleted,
 	UserRole userRole

--- a/src/main/java/cmc/delta/domain/dashboard/application/dto/DashboardProblemItem.java
+++ b/src/main/java/cmc/delta/domain/dashboard/application/dto/DashboardProblemItem.java
@@ -1,0 +1,16 @@
+package cmc.delta.domain.dashboard.application.dto;
+
+import cmc.delta.domain.user.model.enums.UserRole;
+import java.time.LocalDateTime;
+
+public record DashboardProblemItem(
+	Long problemId,
+	String problemName,
+	String unitName,
+	String problemType,
+	long aiSolutionCount,
+	LocalDateTime registeredAt,
+	boolean wrongAnswerCompleted,
+	UserRole userRole
+) {
+}

--- a/src/main/java/cmc/delta/domain/dashboard/application/dto/DashboardProblemsResponse.java
+++ b/src/main/java/cmc/delta/domain/dashboard/application/dto/DashboardProblemsResponse.java
@@ -1,0 +1,12 @@
+package cmc.delta.domain.dashboard.application.dto;
+
+import java.util.List;
+
+public record DashboardProblemsResponse(
+	List<DashboardProblemItem> content,
+	int page,
+	int size,
+	long totalElements,
+	int totalPages
+) {
+}

--- a/src/main/java/cmc/delta/domain/dashboard/application/port/in/DashboardQueryUseCase.java
+++ b/src/main/java/cmc/delta/domain/dashboard/application/port/in/DashboardQueryUseCase.java
@@ -1,6 +1,7 @@
 package cmc.delta.domain.dashboard.application.port.in;
 
 import cmc.delta.domain.dashboard.application.dto.DashboardMonthlyAccessResponse;
+import cmc.delta.domain.dashboard.application.dto.DashboardProblemsResponse;
 import cmc.delta.domain.dashboard.application.dto.DashboardUsersResponse;
 import java.time.YearMonth;
 import org.springframework.data.domain.Pageable;
@@ -10,4 +11,6 @@ public interface DashboardQueryUseCase {
 	DashboardUsersResponse getUsers(Pageable pageable);
 
 	DashboardMonthlyAccessResponse getMonthlyAccess(YearMonth yearMonth);
+
+	DashboardProblemsResponse getProblems(Pageable pageable);
 }

--- a/src/main/java/cmc/delta/domain/dashboard/application/port/out/DashboardMonthlyAccessQueryPort.java
+++ b/src/main/java/cmc/delta/domain/dashboard/application/port/out/DashboardMonthlyAccessQueryPort.java
@@ -1,10 +1,12 @@
 package cmc.delta.domain.dashboard.application.port.out;
 
-import cmc.delta.domain.dashboard.application.dto.DashboardDailyAccessItem;
+import java.time.LocalDate;
 import java.time.YearMonth;
-import java.util.List;
+import java.util.Map;
 
 public interface DashboardMonthlyAccessQueryPort {
 
-	List<DashboardDailyAccessItem> findDailyAccessByMonth(YearMonth yearMonth);
+	Map<LocalDate, Long> findDailyAccessByMonth(YearMonth yearMonth);
+
+	Map<LocalDate, Long> findDailyNewUsersByMonth(YearMonth yearMonth);
 }

--- a/src/main/java/cmc/delta/domain/dashboard/application/port/out/DashboardProblemQueryPort.java
+++ b/src/main/java/cmc/delta/domain/dashboard/application/port/out/DashboardProblemQueryPort.java
@@ -1,0 +1,12 @@
+package cmc.delta.domain.dashboard.application.port.out;
+
+import cmc.delta.domain.dashboard.application.dto.DashboardProblemItem;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface DashboardProblemQueryPort {
+
+	List<DashboardProblemItem> findProblems(Pageable pageable);
+
+	long countProblems();
+}

--- a/src/main/java/cmc/delta/domain/dashboard/application/service/DashboardQueryService.java
+++ b/src/main/java/cmc/delta/domain/dashboard/application/service/DashboardQueryService.java
@@ -2,10 +2,13 @@ package cmc.delta.domain.dashboard.application.service;
 
 import cmc.delta.domain.dashboard.application.dto.DashboardDailyAccessItem;
 import cmc.delta.domain.dashboard.application.dto.DashboardMonthlyAccessResponse;
+import cmc.delta.domain.dashboard.application.dto.DashboardProblemItem;
+import cmc.delta.domain.dashboard.application.dto.DashboardProblemsResponse;
 import cmc.delta.domain.dashboard.application.dto.DashboardUserItem;
 import cmc.delta.domain.dashboard.application.dto.DashboardUsersResponse;
 import cmc.delta.domain.dashboard.application.port.in.DashboardQueryUseCase;
 import cmc.delta.domain.dashboard.application.port.out.DashboardMonthlyAccessQueryPort;
+import cmc.delta.domain.dashboard.application.port.out.DashboardProblemQueryPort;
 import cmc.delta.domain.dashboard.application.port.out.DashboardUserQueryPort;
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -25,6 +28,7 @@ public class DashboardQueryService implements DashboardQueryUseCase {
 
 	private final DashboardUserQueryPort dashboardUserQueryPort;
 	private final DashboardMonthlyAccessQueryPort dashboardMonthlyAccessQueryPort;
+	private final DashboardProblemQueryPort dashboardProblemQueryPort;
 
 	@Override
 	public DashboardUsersResponse getUsers(Pageable pageable) {
@@ -51,5 +55,13 @@ public class DashboardQueryService implements DashboardQueryUseCase {
 			.toList();
 
 		return new DashboardMonthlyAccessResponse(yearMonth.getYear(), yearMonth.getMonthValue(), dailyAccess);
+	}
+
+	@Override
+	public DashboardProblemsResponse getProblems(Pageable pageable) {
+		List<DashboardProblemItem> content = dashboardProblemQueryPort.findProblems(pageable);
+		long totalElements = dashboardProblemQueryPort.countProblems();
+		int totalPages = totalElements == 0 ? 0 : (int) ((totalElements + pageable.getPageSize() - 1) / pageable.getPageSize());
+		return new DashboardProblemsResponse(content, pageable.getPageNumber(), pageable.getPageSize(), totalElements, totalPages);
 	}
 }

--- a/src/main/java/cmc/delta/domain/dashboard/application/service/DashboardQueryService.java
+++ b/src/main/java/cmc/delta/domain/dashboard/application/service/DashboardQueryService.java
@@ -7,8 +7,12 @@ import cmc.delta.domain.dashboard.application.dto.DashboardUsersResponse;
 import cmc.delta.domain.dashboard.application.port.in.DashboardQueryUseCase;
 import cmc.delta.domain.dashboard.application.port.out.DashboardMonthlyAccessQueryPort;
 import cmc.delta.domain.dashboard.application.port.out.DashboardUserQueryPort;
+import java.time.LocalDate;
 import java.time.YearMonth;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -32,7 +36,20 @@ public class DashboardQueryService implements DashboardQueryUseCase {
 
 	@Override
 	public DashboardMonthlyAccessResponse getMonthlyAccess(YearMonth yearMonth) {
-		List<DashboardDailyAccessItem> dailyAccess = dashboardMonthlyAccessQueryPort.findDailyAccessByMonth(yearMonth);
+		Map<LocalDate, Long> accessMap = dashboardMonthlyAccessQueryPort.findDailyAccessByMonth(yearMonth);
+		Map<LocalDate, Long> newUsersMap = dashboardMonthlyAccessQueryPort.findDailyNewUsersByMonth(yearMonth);
+
+		Set<LocalDate> allDates = new HashSet<>(accessMap.keySet());
+		allDates.addAll(newUsersMap.keySet());
+
+		List<DashboardDailyAccessItem> dailyAccess = allDates.stream()
+			.sorted()
+			.map(date -> new DashboardDailyAccessItem(
+				date,
+				accessMap.getOrDefault(date, 0L),
+				newUsersMap.getOrDefault(date, 0L)))
+			.toList();
+
 		return new DashboardMonthlyAccessResponse(yearMonth.getYear(), yearMonth.getMonthValue(), dailyAccess);
 	}
 }

--- a/src/main/java/cmc/delta/domain/problem/adapter/in/web/problem/ProblemController.java
+++ b/src/main/java/cmc/delta/domain/problem/adapter/in/web/problem/ProblemController.java
@@ -186,6 +186,8 @@ public class ProblemController {
 		UserPrincipal principal,
 		@PathVariable
 		Long problemId) {
+		problemCommandUseCase.incrementViewCount(problemId);
+
 		ProblemDetailResponse data = problemQueryUseCase.getMyProblemDetail(principal.userId(), problemId);
 
 		return ApiResponses.success(SuccessCode.OK, data);

--- a/src/main/java/cmc/delta/domain/problem/adapter/out/persistence/problem/ProblemJpaRepository.java
+++ b/src/main/java/cmc/delta/domain/problem/adapter/out/persistence/problem/ProblemJpaRepository.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ProblemJpaRepository extends JpaRepository<Problem, Long>, ProblemRepositoryPort {
@@ -39,4 +40,14 @@ public interface ProblemJpaRepository extends JpaRepository<Problem, Long>, Prob
 	default Optional<Problem> findByScanId(Long scanId) {
 		return findByScan_Id(scanId);
 	}
+
+	@Override
+	@Modifying
+	@Query("update Problem p set p.viewCount = p.viewCount + 1 where p.id = :id")
+	void incrementViewCount(Long id);
+
+	@Override
+	@Modifying
+	@Query("update Problem p set p.aiSolutionCount = p.aiSolutionCount + 1 where p.id = :id")
+	void incrementAiSolutionCount(Long id);
 }

--- a/src/main/java/cmc/delta/domain/problem/application/port/in/problem/ProblemCommandUseCase.java
+++ b/src/main/java/cmc/delta/domain/problem/application/port/in/problem/ProblemCommandUseCase.java
@@ -18,4 +18,6 @@ public interface ProblemCommandUseCase {
 	void updateWrongAnswerCard(Long currentUserId, Long problemId, UpdateWrongAnswerCardCommand request);
 
 	void deleteWrongAnswerCard(Long currentUserId, Long problemId);
+
+	void incrementViewCount(Long problemId);
 }

--- a/src/main/java/cmc/delta/domain/problem/application/port/out/problem/ProblemRepositoryPort.java
+++ b/src/main/java/cmc/delta/domain/problem/application/port/out/problem/ProblemRepositoryPort.java
@@ -18,4 +18,8 @@ public interface ProblemRepositoryPort {
 	boolean existsByOriginalStorageKey(String storageKey);
 
 	boolean existsByScanId(Long scanId);
+
+	void incrementViewCount(Long id);
+
+	void incrementAiSolutionCount(Long id);
 }

--- a/src/main/java/cmc/delta/domain/problem/application/service/command/ProblemAiSolutionCommandServiceImpl.java
+++ b/src/main/java/cmc/delta/domain/problem/application/service/command/ProblemAiSolutionCommandServiceImpl.java
@@ -56,7 +56,7 @@ public class ProblemAiSolutionCommandServiceImpl implements ProblemAiSolutionCom
 		Problem problem = problemRepositoryPort.findByIdAndUserId(problemId, userId)
 			.orElseThrow(() -> new ProblemException(ErrorCode.PROBLEM_NOT_FOUND));
 
-		problem.incrementAiSolutionCount();
+		problemRepositoryPort.incrementAiSolutionCount(problemId);
 
 		LocalDateTime now = LocalDateTime.now(clock);
 		String inputHash = calculateInputHash(problem);

--- a/src/main/java/cmc/delta/domain/problem/application/service/command/ProblemAiSolutionCommandServiceImpl.java
+++ b/src/main/java/cmc/delta/domain/problem/application/service/command/ProblemAiSolutionCommandServiceImpl.java
@@ -56,6 +56,8 @@ public class ProblemAiSolutionCommandServiceImpl implements ProblemAiSolutionCom
 		Problem problem = problemRepositoryPort.findByIdAndUserId(problemId, userId)
 			.orElseThrow(() -> new ProblemException(ErrorCode.PROBLEM_NOT_FOUND));
 
+		problem.incrementAiSolutionCount();
+
 		LocalDateTime now = LocalDateTime.now(clock);
 		String inputHash = calculateInputHash(problem);
 

--- a/src/main/java/cmc/delta/domain/problem/application/service/command/ProblemServiceImpl.java
+++ b/src/main/java/cmc/delta/domain/problem/application/service/command/ProblemServiceImpl.java
@@ -110,6 +110,12 @@ public class ProblemServiceImpl implements ProblemCommandUseCase {
 
 	@Override
 	@Transactional
+	public void incrementViewCount(Long problemId) {
+		problemRepositoryPort.incrementViewCount(problemId);
+	}
+
+	@Override
+	@Transactional
 	public void deleteWrongAnswerCard(Long currentUserId, Long problemId) {
 		Problem problem = loadProblemOrThrow(problemId, currentUserId);
 		String originalStorageKey = problem.getOriginalStorageKey();

--- a/src/main/java/cmc/delta/domain/problem/application/service/query/ProblemQueryServiceImpl.java
+++ b/src/main/java/cmc/delta/domain/problem/application/service/query/ProblemQueryServiceImpl.java
@@ -17,8 +17,10 @@ import cmc.delta.domain.problem.application.port.in.problem.result.ProblemListIt
 import cmc.delta.domain.problem.application.port.in.support.CurriculumItemResponse;
 import cmc.delta.domain.problem.application.port.in.support.CursorQuery;
 import cmc.delta.domain.problem.application.port.in.support.PageQuery;
+import cmc.delta.domain.problem.application.port.out.problem.ProblemRepositoryPort;
 import cmc.delta.domain.problem.application.port.out.problem.query.ProblemQueryPort;
 import cmc.delta.domain.problem.application.port.out.problem.query.ProblemTypeTagQueryPort;
+import cmc.delta.domain.problem.model.problem.Problem;
 import cmc.delta.domain.problem.application.port.out.problem.query.dto.ProblemDetailRow;
 import cmc.delta.domain.problem.application.port.out.problem.query.dto.ProblemListRow;
 import cmc.delta.domain.problem.application.port.out.problem.query.dto.ProblemTypeTagRow;
@@ -37,6 +39,7 @@ public class ProblemQueryServiceImpl implements ProblemQueryUseCase {
 
 	private final ProblemListRequestValidator requestValidator;
 	private final ProblemQueryPort problemQueryPort;
+	private final ProblemRepositoryPort problemRepositoryPort;
 	private final ProblemTypeTagQueryPort problemTypeTagQueryPort;
 	private final StoragePort storagePort;
 	private final ProblemScrollQueryService scrollQueryService;
@@ -85,9 +88,13 @@ public class ProblemQueryServiceImpl implements ProblemQueryUseCase {
 	}
 
 	@Override
+	@Transactional
 	public ProblemDetailResponse getMyProblemDetail(Long userId, Long problemId) {
 		ProblemDetailRow row = problemQueryPort.findMyProblemDetail(userId, problemId)
 			.orElseThrow(() -> new ProblemException(ErrorCode.PROBLEM_NOT_FOUND));
+
+		problemRepositoryPort.findById(row.problemId())
+			.ifPresent(Problem::incrementViewCount);
 
 		String viewUrl = storagePort.issueReadUrl(row.storageKey());
 		return problemDetailMapper.toResponse(row, viewUrl);

--- a/src/main/java/cmc/delta/domain/problem/application/service/query/ProblemQueryServiceImpl.java
+++ b/src/main/java/cmc/delta/domain/problem/application/service/query/ProblemQueryServiceImpl.java
@@ -20,7 +20,6 @@ import cmc.delta.domain.problem.application.port.in.support.PageQuery;
 import cmc.delta.domain.problem.application.port.out.problem.ProblemRepositoryPort;
 import cmc.delta.domain.problem.application.port.out.problem.query.ProblemQueryPort;
 import cmc.delta.domain.problem.application.port.out.problem.query.ProblemTypeTagQueryPort;
-import cmc.delta.domain.problem.model.problem.Problem;
 import cmc.delta.domain.problem.application.port.out.problem.query.dto.ProblemDetailRow;
 import cmc.delta.domain.problem.application.port.out.problem.query.dto.ProblemListRow;
 import cmc.delta.domain.problem.application.port.out.problem.query.dto.ProblemTypeTagRow;
@@ -93,8 +92,7 @@ public class ProblemQueryServiceImpl implements ProblemQueryUseCase {
 		ProblemDetailRow row = problemQueryPort.findMyProblemDetail(userId, problemId)
 			.orElseThrow(() -> new ProblemException(ErrorCode.PROBLEM_NOT_FOUND));
 
-		problemRepositoryPort.findById(row.problemId())
-			.ifPresent(Problem::incrementViewCount);
+		problemRepositoryPort.incrementViewCount(row.problemId());
 
 		String viewUrl = storagePort.issueReadUrl(row.storageKey());
 		return problemDetailMapper.toResponse(row, viewUrl);

--- a/src/main/java/cmc/delta/domain/problem/application/service/query/ProblemQueryServiceImpl.java
+++ b/src/main/java/cmc/delta/domain/problem/application/service/query/ProblemQueryServiceImpl.java
@@ -17,7 +17,6 @@ import cmc.delta.domain.problem.application.port.in.problem.result.ProblemListIt
 import cmc.delta.domain.problem.application.port.in.support.CurriculumItemResponse;
 import cmc.delta.domain.problem.application.port.in.support.CursorQuery;
 import cmc.delta.domain.problem.application.port.in.support.PageQuery;
-import cmc.delta.domain.problem.application.port.out.problem.ProblemRepositoryPort;
 import cmc.delta.domain.problem.application.port.out.problem.query.ProblemQueryPort;
 import cmc.delta.domain.problem.application.port.out.problem.query.ProblemTypeTagQueryPort;
 import cmc.delta.domain.problem.application.port.out.problem.query.dto.ProblemDetailRow;
@@ -38,7 +37,6 @@ public class ProblemQueryServiceImpl implements ProblemQueryUseCase {
 
 	private final ProblemListRequestValidator requestValidator;
 	private final ProblemQueryPort problemQueryPort;
-	private final ProblemRepositoryPort problemRepositoryPort;
 	private final ProblemTypeTagQueryPort problemTypeTagQueryPort;
 	private final StoragePort storagePort;
 	private final ProblemScrollQueryService scrollQueryService;
@@ -87,12 +85,9 @@ public class ProblemQueryServiceImpl implements ProblemQueryUseCase {
 	}
 
 	@Override
-	@Transactional
 	public ProblemDetailResponse getMyProblemDetail(Long userId, Long problemId) {
 		ProblemDetailRow row = problemQueryPort.findMyProblemDetail(userId, problemId)
 			.orElseThrow(() -> new ProblemException(ErrorCode.PROBLEM_NOT_FOUND));
-
-		problemRepositoryPort.incrementViewCount(row.problemId());
 
 		String viewUrl = storagePort.issueReadUrl(row.storageKey());
 		return problemDetailMapper.toResponse(row, viewUrl);

--- a/src/main/java/cmc/delta/domain/problem/model/problem/Problem.java
+++ b/src/main/java/cmc/delta/domain/problem/model/problem/Problem.java
@@ -140,14 +140,6 @@ public class Problem extends BaseTimeEntity {
 		markCompletedAtIfEmpty(now);
 	}
 
-	public void incrementViewCount() {
-		this.viewCount += 1;
-	}
-
-	public void incrementAiSolutionCount() {
-		this.aiSolutionCount += 1;
-	}
-
 	public void updateAnswer(Integer answerChoiceNo, String answerValue) {
 		AnswerFormat format = requireAnswerFormat();
 		if (format == AnswerFormat.CHOICE) {

--- a/src/main/java/cmc/delta/domain/problem/model/problem/Problem.java
+++ b/src/main/java/cmc/delta/domain/problem/model/problem/Problem.java
@@ -79,6 +79,12 @@ public class Problem extends BaseTimeEntity {
 	@Column(name = "completed_at")
 	private LocalDateTime completedAt;
 
+	@Column(name = "view_count", nullable = false)
+	private int viewCount;
+
+	@Column(name = "ai_solution_count", nullable = false)
+	private int aiSolutionCount;
+
 	@OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<ProblemChoice> choices = new ArrayList<>();
 
@@ -132,6 +138,14 @@ public class Problem extends BaseTimeEntity {
 	public void complete(String memoText, java.time.LocalDateTime now) {
 		updateMemoText(memoText);
 		markCompletedAtIfEmpty(now);
+	}
+
+	public void incrementViewCount() {
+		this.viewCount += 1;
+	}
+
+	public void incrementAiSolutionCount() {
+		this.aiSolutionCount += 1;
 	}
 
 	public void updateAnswer(Integer answerChoiceNo, String answerValue) {

--- a/src/main/java/cmc/delta/global/config/swagger/DashboardApiDocs.java
+++ b/src/main/java/cmc/delta/global/config/swagger/DashboardApiDocs.java
@@ -35,4 +35,27 @@ public final class DashboardApiDocs {
 		- totalElements: 전체 사용자 수
 		- totalPages: 전체 페이지 수
 		""";
+
+	public static final String GET_PROBLEMS = """
+		관리자 대시보드의 문제 등록 현황 목록을 조회합니다.
+
+		요청 파라미터:
+		- page: 페이지 번호 (기본값 0)
+		- size: 페이지 크기 (기본값 20, 최대 100)
+
+		응답 필드:
+		- content: 문제 목록
+		  - problemId: 문제 ID
+		  - problemName: 문제명 (problem의 final unit 명)
+		  - unitName: 단원명 (final unit의 parent unit 명, root unit이면 null)
+		  - problemType: 문제 유형명
+		  - aiSolutionCount: AI 풀이 진행 횟수 (task가 존재하면 1, 없으면 0)
+		  - registeredAt: 문제 등록 일시
+		  - wrongAnswerCompleted: 오답 완료 여부 (completedAt 존재 여부)
+		  - userRole: 등록한 사용자 권한 (USER / ADMIN)
+		- page: 현재 페이지 번호
+		- size: 페이지 크기
+		- totalElements: 전체 문제 수
+		- totalPages: 전체 페이지 수
+		""";
 }

--- a/src/main/java/cmc/delta/global/config/swagger/DashboardApiDocs.java
+++ b/src/main/java/cmc/delta/global/config/swagger/DashboardApiDocs.java
@@ -49,7 +49,8 @@ public final class DashboardApiDocs {
 		  - problemName: 문제명 (problem의 final unit 명)
 		  - unitName: 단원명 (final unit의 parent unit 명, root unit이면 null)
 		  - problemType: 문제 유형명
-		  - aiSolutionCount: AI 풀이 진행 횟수 (task가 존재하면 1, 없으면 0)
+		  - aiSolutionCount: AI 풀이 요청 API 누적 호출 수 (캐시 적중 포함, 호출마다 +1)
+		  - viewCount: 문제 상세조회 API 누적 호출 수
 		  - registeredAt: 문제 등록 일시
 		  - wrongAnswerCompleted: 오답 완료 여부 (completedAt 존재 여부)
 		  - userRole: 등록한 사용자 권한 (USER / ADMIN)

--- a/src/main/resources/db/problem/07_problem.sql
+++ b/src/main/resources/db/problem/07_problem.sql
@@ -11,6 +11,8 @@ CREATE TABLE problem (
 	answer_choice_no INT NULL,
 	solution_text MEDIUMTEXT NULL,
 	completed_at DATETIME(6) NULL,
+	view_count INT NOT NULL DEFAULT 0,
+	ai_solution_count INT NOT NULL DEFAULT 0,
 	created_at DATETIME(6) NOT NULL,
 	updated_at DATETIME(6) NOT NULL,
 	PRIMARY KEY (id),


### PR DESCRIPTION
Ⅰ. PR 내용 설명
  관리자 대시보드에 문제 등록 현황 조회 API를 추가하고, 기존 월별 접속자 조회를 보강했습니다.
  1. 문제 등록 현황 조회 API (GET /api/v1/admin/dashboard/problems)
  - 페이지네이션 기반 문제 목록 조회 (기본 size 20, 최대 100)
  - 응답 필드: 문제 ID, 단원명, 대단원명, 문제 유형, AI 풀이 호출 수, 조회 수, 등록 일시, 오답 완료 여부, 등록 사용자
  권한
  2. 문제 조회/풀이 카운터 집계
  - Problem 엔티티에 viewCount, aiSolutionCount 컬럼 추가
  - 문제 상세 조회 API 호출 시 viewCount 증가
  - AI 풀이 요청 API 호출 시 aiSolutionCount 증가 (캐시 적중 포함)
  - 동시성 안전성을 위해 원자적 UPDATE(SET x = x + 1) 방식으로 구현

  3. 월별 일별 접속자 조회 보강
  - DAU 집계에서 ADMIN 권한 사용자 제외
  - 일별 신규 가입자 수(newUsers) 응답 필드 추가
  - DashboardDailyAccessItem.count → dailyVisitors로 필드명 변경
  ---
  Ⅱ. 관련 이슈
  ---
  Ⅲ. 검증 방법
  ---
  Ⅳ. 리뷰 시 참고 사항

  1. Breaking change — 어드민 프론트 동기화 필요
  DashboardDailyAccessItem의 JSON 필드명이 count → dailyVisitors로 변경됐습니다. 어드민 프론트가 기존 필드를 참조
  중이라면 동시 배포가 필요합니다.

  2. 카운터 증가 구현 방식
  조회수/AI 호출수 증가는 엔티티 load-modify-save 대신 JPQL @Modifying UPDATE로 처리했습니다.
  - DB 왕복 1회 (SELECT + UPDATE → UPDATE 1회)
  - InnoDB row-level 락으로 lost update 방지
  - @LastModifiedDate 라이프사이클을 거치지 않아 단순 조회가 updated_at을 갱신하지 않음
