### PR TITLE
feat: logout api는 토큰 받도록 수정

### DIFF
--- a/src/main/java/cmc/delta/global/config/security/SecurityConfig.java
+++ b/src/main/java/cmc/delta/global/config/security/SecurityConfig.java
@@ -42,11 +42,19 @@ public class SecurityConfig {
 	};
 
 	private static final String[] PUBLIC_POST_PATHS = {
-		"/api/v1/auth/**"
+		"/api/v1/auth/kakao",
+		"/api/v1/auth/google",
+		"/api/v1/auth/apple",
+		"/api/v1/auth/apple/exchange",
+		"/api/v1/auth/reissue"
 	};
 
 	public static final String[] JWT_SKIP_PATHS = {
-		"/api/v1/auth/",
+		"/api/v1/auth/kakao",
+		"/api/v1/auth/google",
+		"/api/v1/auth/apple",
+		"/api/v1/auth/apple/exchange",
+		"/api/v1/auth/reissue",
 		"/apple/callback"
 	};
 

--- a/src/main/java/cmc/delta/global/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/cmc/delta/global/config/security/jwt/JwtAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	protected boolean shouldNotFilter(HttpServletRequest request) {
 		String uri = request.getRequestURI();
 		for (String path : SecurityConfig.JWT_SKIP_PATHS) {
-			if (uri.startsWith(path)) {
+			if (uri.equals(path)) {
 				return true;
 			}
 		}

--- a/src/test/java/cmc/delta/global/config/security/jwt/JwtAuthenticationFilterSkipTest.java
+++ b/src/test/java/cmc/delta/global/config/security/jwt/JwtAuthenticationFilterSkipTest.java
@@ -40,6 +40,7 @@ class JwtAuthenticationFilterSkipTest {
 			"/api/v1/auth/kakao",
 			"/api/v1/auth/google",
 			"/api/v1/auth/apple",
+			"/api/v1/auth/apple/exchange",
 			"/api/v1/auth/reissue",
 			"/apple/callback");
 	}
@@ -63,6 +64,8 @@ class JwtAuthenticationFilterSkipTest {
 	@ValueSource(strings = {
 		"/api/v1/problems",
 		"/api/v1/users/me",
+		"/api/v1/auth/logout",
+		"/api/v1/auth/kakao/extra",
 		"/api/v1/auth-other/something"
 	})
 	@DisplayName("JWT_SKIP_PATHS에 해당하지 않는 경로는 필터를 통과함")
@@ -87,7 +90,7 @@ class JwtAuthenticationFilterSkipTest {
 		request.setRequestURI(path);
 
 		boolean expectedSkip = Stream.of(SecurityConfig.JWT_SKIP_PATHS)
-			.anyMatch(path::startsWith);
+			.anyMatch(path::equals);
 
 		// when
 		boolean actualSkip = filter.shouldNotFilter(request);


### PR DESCRIPTION
**Ⅰ. PR 내용 설명 (Describe what this PR did)**  
logout 시 500 발생 문제가 있어 logout api는 토큰을 받도록 수정하고, filter에서 startswith를 equals로 수정
